### PR TITLE
Document CLI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,9 @@ jobs:
     - name: Test
       run: cargo test --verbose --workspace
 
+    - name: Test CLI
+      run: cli/tests/example.sh
+
     - name: Install Rust Android targets
       run: make -C lib install-rustup-android
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -104,6 +104,10 @@ Corresponds to [/verify/presentations](https://w3c-ccg.github.io/vc-http-api/#/V
 
 Options and output format are the same as for [didkit vc-verify-credential](#didkit-vc-verify-credential).
 
+## Examples
+
+See the included [shell script](tests/example.sh).
+
 [JWK]: https://tools.ietf.org/html/rfc7517
 [ld-proofs]: https://w3c-ccg.github.io/ld-proofs/
 [vc-http-api]: https://w3c-ccg.github.io/vc-http-api/

--- a/cli/tests/.gitignore
+++ b/cli/tests/.gitignore
@@ -1,0 +1,6 @@
+credential-signed.jsonld
+credential-verify-result.json
+key.jwk
+presentation-signed.jsonld
+presentation-unsigned-constructed.jsonld
+presentation-verify-result.json

--- a/cli/tests/example.sh
+++ b/cli/tests/example.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+# Example script using DIDKit for key generation, credential/presentation
+# issuance and verification.
+
+# Exit if anything fails
+set -e
+
+# Pretty-print JSON
+print_json() {
+	file=${1?file}
+	if command -v jq >/dev/null 2>&1; then
+		jq . "$file"
+	elif command -v json_pp >/dev/null 2>&1; then
+		json_pp "$file"
+	else
+		cat "$file"
+	fi
+}
+
+# Run in source directory
+cd "$(dirname "$0")"
+
+# Build didkit CLI
+cargo build -p didkit_cli
+
+# Get didkit in $PATH
+export PATH=$PWD/../../target/debug:$PATH
+
+# Create a keypair if needed
+if [ -e key.jwk ]; then
+	echo 'Using existing keypair.'
+else
+	didkit generate-ed25519-key > key.jwk
+	echo 'Generated keypair.'
+fi
+echo
+
+# Get DID (did:key) for keypair
+did=$(didkit key-to-did-key -k key.jwk)
+printf 'DID: %s\n\n' "$did"
+
+# Issue verifiable credential
+didkit vc-issue-credential \
+	-k key.jwk \
+	-v "$did" \
+	-p assertionMethod \
+	< credential-unsigned.jsonld \
+	> credential-signed.jsonld
+echo 'Issued verifiable credential:'
+print_json credential-signed.jsonld
+echo
+
+# Verify verifiable credential
+didkit vc-verify-credential \
+	-p assertionMethod \
+	< credential-signed.jsonld \
+	> credential-verify-result.json
+echo 'Verified verifiable credential:'
+print_json credential-verify-result.json
+echo
+
+# Create presentation embedding verifiable credential
+{
+	echo '{"verifiableCredential": '
+	cat credential-signed.jsonld
+	echo ','
+	tail +2 presentation-unsigned.jsonld
+} > presentation-unsigned-constructed.jsonld
+echo 'Created presentation.'
+echo
+
+# Issue verifiable presentation
+didkit vc-issue-presentation \
+	-k key.jwk \
+	-v "$did" \
+	-p authentication \
+	< presentation-unsigned-constructed.jsonld \
+	> presentation-signed.jsonld
+echo 'Issued verifiable presentation:'
+print_json presentation-signed.jsonld
+echo
+
+# Verify verifiable presentation
+didkit vc-verify-presentation \
+	-p authentication \
+	< presentation-signed.jsonld \
+	> presentation-verify-result.json
+echo 'Verified verifiable presentation:'
+print_json presentation-verify-result.json


### PR DESCRIPTION
This adds a readme for the `didkit` CLI with command usage information, and a shell script demonstrating the CLI.

Eventually the command documentation could be combined with that of other components (C library, etc.) since they all provide the same set of commands/functions. But for now, the CLI gets its own documentation in the README.

The shell script is intended to be easily readable in source and in output, while demonstrating most or all of DIDKit's API. It also functions as a test, and is added to the CI.