### PR TITLE
Use URI with fragment for verificationMethod

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         repository: spruceid/ssi
         token: ${{ secrets.GH_ACCESS_TOKEN_CEL }}
         path: ssi
-        ref: 729f1efb61ee3c545c65becd9858ebb196331cfb
+        ref: 79d434979d10769dce0f6ba32241b559d5307320
 
     - name: Cache Cargo registry and build artifacts
       uses: actions/cache@v2

--- a/cli/README.md
+++ b/cli/README.md
@@ -29,6 +29,10 @@ Given a [JWK][], output the corresponding [did:key][].
 
 Currently, this only supports [Ed25519](https://tools.ietf.org/html/rfc8037#appendix-A.2) keys.
 
+### `didkit key-to-verification-method`
+
+Given a Ed25519 [JWK][], output the corresponding [did:key][] [verificationMethod][].
+
 #### Options
 
 - `-k, --key <file>` (required) - Name of JWK file

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -18,6 +18,11 @@ pub enum DIDKit {
         #[structopt(short, long, parse(from_os_str))]
         key: PathBuf,
     },
+    /// Output a verificationMethod for a JWK
+    KeyToVerificationMethod {
+        #[structopt(short, long, parse(from_os_str))]
+        key: PathBuf,
+    },
 
     /*
     // DID Functionality
@@ -123,6 +128,12 @@ fn main() {
         DIDKit::KeyToDIDKey { key: key_path } => {
             let key = read_key(key_path);
             let did = key.to_did().unwrap();
+            println!("{}", did);
+        }
+
+        DIDKit::KeyToVerificationMethod { key: key_path } => {
+            let key = read_key(key_path);
+            let did = key.to_verification_method().unwrap();
             println!("{}", did);
         }
 

--- a/cli/tests/example.sh
+++ b/cli/tests/example.sh
@@ -39,6 +39,10 @@ echo
 did=$(didkit key-to-did-key -k key.jwk)
 printf 'DID: %s\n\n' "$did"
 
+# Get verificationMethod for keypair
+verification_method=$(didkit key-to-verification-method -k key.jwk)
+printf 'verificationMethod: %s\n\n' "$verification_method"
+
 # Prepare credential for issuing
 cat > credential-unsigned.jsonld <<EOF
 {
@@ -56,7 +60,7 @@ EOF
 # Issue verifiable credential
 didkit vc-issue-credential \
 	-k key.jwk \
-	-v "$did" \
+	-v "$verification_method" \
 	-p assertionMethod \
 	< credential-unsigned.jsonld \
 	> credential-signed.jsonld
@@ -66,7 +70,7 @@ echo
 
 # Verify verifiable credential
 if ! didkit vc-verify-credential \
-	-v "$did" \
+	-v "$verification_method" \
 	-p assertionMethod \
 	< credential-signed.jsonld \
 	> credential-verify-result.json
@@ -93,7 +97,7 @@ EOF
 # Issue verifiable presentation
 didkit vc-issue-presentation \
 	-k key.jwk \
-	-v "$did" \
+	-v "$verification_method" \
 	-p authentication \
 	< presentation-unsigned.jsonld \
 	> presentation-signed.jsonld
@@ -103,7 +107,7 @@ echo
 
 # Verify verifiable presentation
 if ! didkit vc-verify-presentation \
-	-v "$did" \
+	-v "$verification_method" \
 	-p authentication \
 	< presentation-signed.jsonld \
 	> presentation-verify-result.json

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -350,7 +350,7 @@ impl DIDKitHTTPMakeSvc {
     pub fn new(keys: Vec<JWK>) -> Self {
         Self {
             keys: keys.into_iter().fold(KeyMap::new(), |mut map, key| {
-                map.insert(key.to_did().unwrap(), key);
+                map.insert(key.to_verification_method().unwrap(), key);
                 map
             }),
         }

--- a/lib/c/test.c
+++ b/lib/c/test.c
@@ -25,7 +25,11 @@ int main() {
 
     // Get did:key for key
     const char *did = didkit_key_to_did(key);
-    if (key == NULL) errx(1, "key to did: %s", didkit_error_message());
+    if (did == NULL) errx(1, "key to did: %s", didkit_error_message());
+
+    // Get verificationMethod for key
+    const char *verification_method = didkit_key_to_verification_method(key);
+    if (verification_method == NULL) errx(1, "key to did: %s", didkit_error_message());
 
     // Issue Credential
     char credential[0x1000];
@@ -43,7 +47,7 @@ int main() {
     snprintf(vc_options, sizeof vc_options, "{"
             "  \"proofPurpose\": \"assertionMethod\","
             "  \"verificationMethod\": \"%s\""
-            "}", did);
+            "}", verification_method);
     const char *vc = didkit_vc_issue_credential(credential, vc_options, key);
     if (vc == NULL) errx(1, "issue credential: %s", didkit_error_message());
 
@@ -67,7 +71,7 @@ int main() {
     snprintf(vp_options, sizeof vp_options, "{"
             "  \"proofPurpose\": \"authentication\","
             "  \"verificationMethod\": \"%s\""
-            "}", did);
+            "}", verification_method);
     vp = didkit_vc_issue_presentation(presentation, vp_options, key);
     if (vp == NULL) errx(1, "issue presentation: %s", didkit_error_message());
 
@@ -80,6 +84,7 @@ int main() {
 
     didkit_free_string(vp);
     didkit_free_string(vc);
+    didkit_free_string(verification_method);
     didkit_free_string(did);
     didkit_free_string(key);
 }

--- a/lib/flutter/lib/didkit.dart
+++ b/lib/flutter/lib/didkit.dart
@@ -24,6 +24,9 @@ final generate_ed25519_key = lib
 final key_to_did_key = lib
   .lookupFunction<Pointer<Utf8> Function(Pointer<Utf8>), Pointer<Utf8> Function(Pointer<Utf8>)>('didkit_key_to_did');
 
+final key_to_verification_method = lib
+  .lookupFunction<Pointer<Utf8> Function(Pointer<Utf8>), Pointer<Utf8> Function(Pointer<Utf8>)>('didkit_key_to_verification_method');
+
 final issue_credential = lib
   .lookupFunction<Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>), Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)>('didkit_vc_issue_credential');
 
@@ -78,6 +81,14 @@ class DIDKit {
     final did_key_string = Utf8.fromUtf8(did_key);
     free_string(did_key);
     return did_key_string;
+  }
+
+  static String keyToVerificationMethod(String key) {
+    final vm = key_to_verification_method(Utf8.toUtf8(key));
+    if (vm.address == nullptr.address) throw lastError();
+    final vm_string = Utf8.fromUtf8(vm);
+    free_string(vm);
+    return vm_string;
   }
 
   static String issueCredential(String credential, String options, String key) {

--- a/lib/flutter/test/didkit_test.dart
+++ b/lib/flutter/test/didkit_test.dart
@@ -27,9 +27,10 @@ void main() {
   test('issueCredential, verifyCredential', () async {
     final key = DIDKit.generateEd25519Key();
     final did = DIDKit.keyToDIDKey(key);
+    final verificationMethod = DIDKit.keyToVerificationMethod(key);
     final options = {
         "proofPurpose": "assertionMethod",
-        "verificationMethod": did
+        "verificationMethod": verificationMethod
     };
     final credential = {
         "@context": "https://www.w3.org/2018/credentials/v1",
@@ -53,9 +54,10 @@ void main() {
   test('issuePresentation, verifyPresentation', () async {
     final key = DIDKit.generateEd25519Key();
     final did = DIDKit.keyToDIDKey(key);
+    final verificationMethod = DIDKit.keyToVerificationMethod(key);
     final options = {
         "proofPurpose": "authentication",
-        "verificationMethod": did
+        "verificationMethod": verificationMethod
     };
     final presentation = {
         "@context": ["https://www.w3.org/2018/credentials/v1"],

--- a/lib/java/main/com/spruceid/DIDKit.java
+++ b/lib/java/main/com/spruceid/DIDKit.java
@@ -6,6 +6,7 @@ public class DIDKit {
     public static native String getVersion();
     public static native String generateEd25519Key() throws DIDKitException;
     public static native String keyToDID(String jwk) throws DIDKitException;
+    public static native String keyToVerificationMethod(String jwk) throws DIDKitException;
     public static native String issueCredential(String credential, String linkedDataProofOptions, String key) throws DIDKitException;
     public static native String verifyCredential(String verifiableCredential, String linkedDataProofOptions);
     public static native String issuePresentation(String presentation, String linkedDataProofOptions, String key) throws DIDKitException;

--- a/lib/java/test/com/spruceid/DIDKitTest.java
+++ b/lib/java/test/com/spruceid/DIDKitTest.java
@@ -12,6 +12,9 @@ class DIDKitTest {
         // Convert key to DID
         String did = DIDKit.keyToDID(jwk);
 
+        // Get verificationMethod for DID
+        String verificationMethod = DIDKit.keyToVerificationMethod(jwk);
+
         // Trigger Exception
         boolean threw = false;
         try {
@@ -34,7 +37,7 @@ class DIDKitTest {
             + "}";
         String vcOptions = "{"
             + "  \"proofPurpose\": \"assertionMethod\","
-            + "  \"verificationMethod\": \"" + did + "\""
+            + "  \"verificationMethod\": \"" + verificationMethod + "\""
             + "}";
         String vc = DIDKit.issueCredential(credential, vcOptions, jwk);
 
@@ -55,7 +58,7 @@ class DIDKitTest {
             + "}";
         String vpOptions = "{"
             + "  \"proofPurpose\": \"authentication\","
-            + "  \"verificationMethod\": \"" + did + "\""
+            + "  \"verificationMethod\": \"" + verificationMethod + "\""
             + "}";
         String vp = DIDKit.issuePresentation(presentation, vpOptions, jwk);
 

--- a/lib/src/c.rs
+++ b/lib/src/c.rs
@@ -51,6 +51,18 @@ pub extern "C" fn didkit_key_to_did(jwk: *const c_char) -> *const c_char {
     ccchar_or_error(key_to_did(jwk))
 }
 
+// Convert JWK to did:key DID URI for verificationMethod
+fn key_to_verification_method(key_json_ptr: *const c_char) -> Result<*const c_char, Error> {
+    let key_json = unsafe { CStr::from_ptr(key_json_ptr) }.to_str()?;
+    let key: JWK = serde_json::from_str(key_json)?;
+    let did = key.to_verification_method()?;
+    Ok(CString::new(did)?.into_raw())
+}
+#[no_mangle]
+pub extern "C" fn didkit_key_to_verification_method(jwk: *const c_char) -> *const c_char {
+    ccchar_or_error(key_to_verification_method(jwk))
+}
+
 // Issue Credential
 fn issue_credential(
     credential_json_ptr: *const c_char,

--- a/lib/src/jni.rs
+++ b/lib/src/jni.rs
@@ -62,6 +62,22 @@ pub extern "system" fn Java_com_spruceid_DIDKit_keyToDID(
     jstring_or_error(&env, key_to_did(&env, jwk))
 }
 
+fn key_to_verification_method(env: &JNIEnv, key_jstring: JString) -> Result<jstring, Error> {
+    let key_json: String = env.get_string(key_jstring).unwrap().into();
+    let key: JWK = serde_json::from_str(&key_json)?;
+    let verification_method = key.to_verification_method()?;
+    Ok(env.new_string(verification_method).unwrap().into_inner())
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_spruceid_DIDKit_keyToVerificationMethod(
+    env: JNIEnv,
+    _class: JClass,
+    jwk: JString,
+) -> jstring {
+    jstring_or_error(&env, key_to_verification_method(&env, jwk))
+}
+
 fn issue_credential(
     env: &JNIEnv,
     credential_jstring: JString,


### PR DESCRIPTION
This update integrates https://github.com/spruceid/ssi/pull/42.

For ld-proof `verificationMethod`, we use a DID URL with the fragment part (`did:key:<hash>#<hash>`), rather than just the DID (`did:key:<hash>`). 

For ease of use, I add a `key-to-verification-method` function and API methods - similar to the existing `key-to-did-key` function/methods. Tests are updated accordingly.

Existing credentials can still be verified by setting the verificationMethod accordingly in the proof verify options. But the default verificationMethod will now be the issuer/holder's DID URL with fragment rather than just their DID.