### PR TITLE
Update ssi and vc-http-api in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,13 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-cargo-
 
+    - name: Install Rust nightly
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        profile: minimal
+        default: true
+
     - name: Build
       run: cargo build --verbose --workspace
 


### PR DESCRIPTION
Update CI to use `ssi` @ https://github.com/spruceid/ssi/pull/47.

Update CI to use `vc-http-api` @ https://github.com/spruceid/vc-http-api/commit/a7dcc3ed7c96f93059860511d19b384700fb43cc, which has new test fixtures following https://github.com/spruceid/ssi/pull/47 which fixed a bug in calculating signing input for VPs.

Update CI to use Rust nightly, as needed for the `json-ld` crate.