### PR TITLE
Use Rust nightly for building Docker images

### DIFF
--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -1,4 +1,4 @@
-FROM ekidd/rust-musl-builder as builder
+FROM ekidd/rust-musl-builder:nightly-2021-01-01 as builder
 
 ADD --chown=rust:rust . /didkit
 ADD --chown=rust:rust ./ssi /ssi

--- a/Dockerfile-http
+++ b/Dockerfile-http
@@ -1,4 +1,4 @@
-FROM ekidd/rust-musl-builder as builder
+FROM ekidd/rust-musl-builder:nightly-2021-01-01 as builder
 
 ADD --chown=rust:rust . /didkit
 ADD --chown=rust:rust ./ssi /ssi


### PR DESCRIPTION
We need to use Rust nightly since #21. The `ci` workflow was updated to use Rust nightly: https://github.com/spruceid/didkit/pull/21/commits/07942ed991a9166ea8556d19e558481a91b5c52e. But the `push_image` workflow failed, as it has to be separately updated for building in Docker: https://github.com/spruceid/didkit/runs/1652702047

https://github.com/emk/rust-musl-builder has tagged Docker images for different Rust versions. To list the tags:
```
curl https://registry.hub.docker.com/v1/repositories/ekidd/rust-musl-builder/tags|jq -c .[]
```
"nightly" is listed but that did not work: https://github.com/spruceid/didkit/runs/1652827201
so I used "nightly-2021-01-01" instead. Workflow run completed: https://github.com/spruceid/didkit/runs/1652846307

I added temporary commits to trigger CI to run on this branch. The PR doesn't have the temporary commit now so it doesn't show the status, but you can check that the commit on which the workflow ran and completed has this PR commit as its parent.