### PR TITLE
Document C functions

### DIFF
--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -49,6 +49,9 @@ impl Error {
 }
 
 #[no_mangle]
+/// Retrieve a human-readable description of the most recent error encountered by a DIDKit C
+/// function. The returned string is valid until the next call to a DIDKit function in the current
+/// thread, and should not be mutated or freed. If there has not been any error, `NULL` is returned.
 pub extern "C" fn didkit_error_message() -> *const c_char {
     LAST_ERROR.with(|error| match error.try_borrow() {
         Ok(maybe_err_ref) => match &*maybe_err_ref {
@@ -60,6 +63,8 @@ pub extern "C" fn didkit_error_message() -> *const c_char {
 }
 
 #[no_mangle]
+/// Retrieve a numeric code for the most recent error encountered by a DIDKit C function. If there
+/// has not been an error, 0 is returned.
 pub extern "C" fn didkit_error_code() -> c_int {
     LAST_ERROR.with(|error| match error.try_borrow() {
         Ok(maybe_err_ref) => match &*maybe_err_ref {


### PR DESCRIPTION
Add explanatory text for DIDKit's C API functions, including about handling errors, and what pointers should be freed or not.

- Most functions take JSON C strings and return new JSON C strings.
- Dynamically allocated strings returned by DIDKit must be freed using didkit_free_string.
- Error messages and codes can be retrieved using didkit_error_message and didkit_error_code, respectively.
- Verification functions may return errors in the verification result also.
- Error messages must not be freed or used after a subsequent call to a DIDKit function.

The error handling was inspired by this guide:
https://michael-f-bryan.github.io/rust-ffi-guide/errors/return_types.html