### PR TITLE
Clone ssi with submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ We depend on some Rust nightly features. When installing with Rustup, pick the n
 
 Spruce's [ssi][] library must be cloned alongside the `didkit` repository:
 ```sh
-$ git clone https://github.com/spruceid/ssi ../ssi
+$ git clone https://github.com/spruceid/ssi ../ssi --recurse-submodules
 ```
 
 Build DIDKit using [Cargo][]:


### PR DESCRIPTION
Since ssi now uses git submodules for json-ld test suites, we must note to get submodules when cloning the repo.