### PR TITLE
Modularize DID methods

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         repository: spruceid/ssi
         token: ${{ secrets.GH_ACCESS_TOKEN_CEL }}
         path: ssi
-        ref: 71daa2663f3a6af00ba7f89d37ed5dd10afba8cc
+        ref: 373c60a1441a8340ce8b5add1ff758c18295940a
 
     - name: Cache Cargo registry and build artifacts
       uses: actions/cache@v2

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,6 +10,7 @@ didkit = { path = "../lib" }
 serde_json = "1.0"
 structopt = "0.3"
 async-std = { version = "1.5", features = ["attributes"] }
+did-key = { path = "../../ssi/did-key" }
 
 [[bin]]
 path = "src/main.rs"

--- a/cli/README.md
+++ b/cli/README.md
@@ -23,15 +23,15 @@ Output help about `didkit` and its subcommands.
 
 Generate a Ed25519 keypair and output it in [JWK format](https://tools.ietf.org/html/rfc8037#appendix-A.1).
 
-### `didkit key-to-did-key`
+### `didkit key-to-did <method_name>`
 
-Given a [JWK][], output the corresponding [did:key][].
+Given a [JWK][] and a DID method name, output the corresponding DID.
 
-Currently, this only supports [Ed25519](https://tools.ietf.org/html/rfc8037#appendix-A.2) keys.
+Currently, this only supports [Ed25519](https://tools.ietf.org/html/rfc8037#appendix-A.2) keys, and [did:key][].
 
-### `didkit key-to-verification-method`
+### `didkit key-to-verification-method <method_name>`
 
-Given a Ed25519 [JWK][], output the corresponding [did:key][] [verificationMethod][].
+Given a Ed25519 [JWK][] and a supported DID method name, output the corresponding [verificationMethod][].
 
 #### Options
 

--- a/cli/tests/cli.rs
+++ b/cli/tests/cli.rs
@@ -15,7 +15,7 @@ fn generate_key() {
 fn issue_verify_credential_presentation() {
     // Get DID for key
     let did_output = Command::new(BIN)
-        .args(&["key-to-did-key", "--key-path", "tests/ed25519-key.jwk"])
+        .args(&["key-to-did", "key", "--key-path", "tests/ed25519-key.jwk"])
         .stderr(Stdio::inherit())
         .output()
         .unwrap();

--- a/cli/tests/example.sh
+++ b/cli/tests/example.sh
@@ -37,12 +37,12 @@ echo
 
 # Get the keypair's did:key DID.
 # More info about did:key: https://w3c-ccg.github.io/did-method-key/
-did=$(didkit key-to-did-key -k key.jwk)
+did=$(didkit key-to-did key -k key.jwk)
 printf 'DID: %s\n\n' "$did"
 
 # Get verificationMethod for keypair.
 # This is used to identify the key in linked data proofs.
-verification_method=$(didkit key-to-verification-method -k key.jwk)
+verification_method=$(didkit key-to-verification-method key -k key.jwk)
 printf 'verificationMethod: %s\n\n' "$verification_method"
 
 # Prepare credential for issuing.

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -14,3 +14,6 @@ bytes = "0.5"
 hyper = "0.13"
 tower-service = "0.3"
 futures-util = { version = "0.3", default-features = false }
+
+[dev-dependencies]
+did-key = { path = "../../ssi/did-key" }

--- a/http/tests/example.sh
+++ b/http/tests/example.sh
@@ -38,12 +38,12 @@ echo
 
 # Get the keypair's did:key DID.
 # More info about did:key: https://w3c-ccg.github.io/did-method-key/
-did=$(didkit key-to-did-key -k key.jwk)
+did=$(didkit key-to-did key -k key.jwk)
 printf 'DID: %s\n' "$did"
 
 # Get verificationMethod for keypair.
 # This is used to identify the key in linked data proofs.
-verification_method=$(didkit key-to-verification-method -k key.jwk)
+verification_method=$(didkit key-to-verification-method key -k key.jwk)
 printf 'verificationMethod: %s\n' "$verification_method"
 
 # Start the HTTP server

--- a/http/tests/main.rs
+++ b/http/tests/main.rs
@@ -199,9 +199,12 @@ async fn credential_presentation_issue_verify() {
 
 #[tokio::test]
 async fn credential_issue_verify_other_key() {
+    use did_key::DIDKey;
+    use didkit::{get_verification_method, DIDMethod, Source};
     let key = JWK::generate_ed25519().unwrap();
-    let did = key.to_did().unwrap();
-    let verification_method = key.to_verification_method().unwrap();
+    let did = DIDKey.generate(&Source::Key(&key)).unwrap();
+    let resolver = DIDKey.to_resolver();
+    let verification_method = get_verification_method(&did, resolver).await.unwrap();
     let (base, shutdown) = serve(Some(vec![key]));
     let client = Client::builder().build_http::<Body>();
     // Issue credential

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -7,9 +7,13 @@ edition = "2018"
 [dependencies]
 #didkit_cbindings = { path = "cbindings/" }
 ssi = { path = "../../ssi" }
+did-key = { path = "../../ssi/did-key" }
+#did-tezos = { path = "../../ssi/did-tezos" }
 serde_json = "1.0"
 jni = "0.17"
 async-std = "1.8"
+async-trait = "0.1"
+lazy_static = "1.4"
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/lib/c/test.c
+++ b/lib/c/test.c
@@ -24,11 +24,11 @@ int main() {
     if (key == NULL) errx(1, "generate key: %s", didkit_error_message());
 
     // Get did:key for key
-    const char *did = didkit_key_to_did(key);
+    const char *did = didkit_key_to_did("key", key);
     if (did == NULL) errx(1, "key to did: %s", didkit_error_message());
 
     // Get verificationMethod for key
-    const char *verification_method = didkit_key_to_verification_method(key);
+    const char *verification_method = didkit_key_to_verification_method("key", key);
     if (verification_method == NULL) errx(1, "key to did: %s", didkit_error_message());
 
     // Issue Credential

--- a/lib/flutter/lib/didkit.dart
+++ b/lib/flutter/lib/didkit.dart
@@ -21,11 +21,11 @@ final get_error_code = lib
 final generate_ed25519_key = lib
   .lookupFunction<Pointer<Utf8> Function(), Pointer<Utf8> Function()>('didkit_vc_generate_ed25519_key');
 
-final key_to_did_key = lib
-  .lookupFunction<Pointer<Utf8> Function(Pointer<Utf8>), Pointer<Utf8> Function(Pointer<Utf8>)>('didkit_key_to_did');
+final key_to_did = lib
+  .lookupFunction<Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>), Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>)>('didkit_key_to_did');
 
 final key_to_verification_method = lib
-  .lookupFunction<Pointer<Utf8> Function(Pointer<Utf8>), Pointer<Utf8> Function(Pointer<Utf8>)>('didkit_key_to_verification_method');
+  .lookupFunction<Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>), Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>)>('didkit_key_to_verification_method');
 
 final issue_credential = lib
   .lookupFunction<Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>), Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)>('didkit_vc_issue_credential');
@@ -75,16 +75,25 @@ class DIDKit {
     return key_string;
   }
 
+  @Deprecated('Use [keyToDID]')
   static String keyToDIDKey(String key) {
-    final did_key = key_to_did_key(Utf8.toUtf8(key));
+    final did_key = key_to_did(Utf8.toUtf8("key"), Utf8.toUtf8(key));
     if (did_key.address == nullptr.address) throw lastError();
     final did_key_string = Utf8.fromUtf8(did_key);
     free_string(did_key);
     return did_key_string;
   }
 
-  static String keyToVerificationMethod(String key) {
-    final vm = key_to_verification_method(Utf8.toUtf8(key));
+  static String keyToDID(String methodName, String key) {
+    final did = key_to_did(Utf8.toUtf8(methodName), Utf8.toUtf8(key));
+    if (did.address == nullptr.address) throw lastError();
+    final did_string = Utf8.fromUtf8(did);
+    free_string(did);
+    return did_string;
+  }
+
+  static String keyToVerificationMethod(String methodName, String key) {
+    final vm = key_to_verification_method(Utf8.toUtf8(methodName), Utf8.toUtf8(key));
     if (vm.address == nullptr.address) throw lastError();
     final vm_string = Utf8.fromUtf8(vm);
     free_string(vm);

--- a/lib/flutter/test/didkit_test.dart
+++ b/lib/flutter/test/didkit_test.dart
@@ -18,16 +18,16 @@ void main() {
     expect(DIDKit.generateEd25519Key(), isInstanceOf<String>());
   });
 
-  test('keyToDIDKey', () async {
+  test('keyToDID', () async {
     final key = DIDKit.generateEd25519Key();
-    final did = DIDKit.keyToDIDKey(key);
+    final did = DIDKit.keyToDID("key", key);
     expect(did, isInstanceOf<String>());
   });
 
   test('issueCredential, verifyCredential', () async {
     final key = DIDKit.generateEd25519Key();
-    final did = DIDKit.keyToDIDKey(key);
-    final verificationMethod = DIDKit.keyToVerificationMethod(key);
+    final did = DIDKit.keyToDID("key", key);
+    final verificationMethod = DIDKit.keyToVerificationMethod("key", key);
     final options = {
         "proofPurpose": "assertionMethod",
         "verificationMethod": verificationMethod
@@ -53,8 +53,8 @@ void main() {
 
   test('issuePresentation, verifyPresentation', () async {
     final key = DIDKit.generateEd25519Key();
-    final did = DIDKit.keyToDIDKey(key);
-    final verificationMethod = DIDKit.keyToVerificationMethod(key);
+    final did = DIDKit.keyToDID("key", key);
+    final verificationMethod = DIDKit.keyToVerificationMethod("key", key);
     final options = {
         "proofPurpose": "authentication",
         "verificationMethod": verificationMethod

--- a/lib/java/main/com/spruceid/DIDKit.java
+++ b/lib/java/main/com/spruceid/DIDKit.java
@@ -5,8 +5,8 @@ import com.spruceid.DIDKitException;
 public class DIDKit {
     public static native String getVersion();
     public static native String generateEd25519Key() throws DIDKitException;
-    public static native String keyToDID(String jwk) throws DIDKitException;
-    public static native String keyToVerificationMethod(String jwk) throws DIDKitException;
+    public static native String keyToDID(String methodName, String jwk) throws DIDKitException;
+    public static native String keyToVerificationMethod(String methodName, String jwk) throws DIDKitException;
     public static native String issueCredential(String credential, String linkedDataProofOptions, String key) throws DIDKitException;
     public static native String verifyCredential(String verifiableCredential, String linkedDataProofOptions);
     public static native String issuePresentation(String presentation, String linkedDataProofOptions, String key) throws DIDKitException;

--- a/lib/java/test/com/spruceid/DIDKitTest.java
+++ b/lib/java/test/com/spruceid/DIDKitTest.java
@@ -10,15 +10,15 @@ class DIDKitTest {
         String jwk = DIDKit.generateEd25519Key();
 
         // Convert key to DID
-        String did = DIDKit.keyToDID(jwk);
+        String did = DIDKit.keyToDID("key", jwk);
 
         // Get verificationMethod for DID
-        String verificationMethod = DIDKit.keyToVerificationMethod(jwk);
+        String verificationMethod = DIDKit.keyToVerificationMethod("key", jwk);
 
         // Trigger Exception
         boolean threw = false;
         try {
-            DIDKit.keyToDID("{}");
+            DIDKit.keyToDID("key", "{}");
         } catch (DIDKitException e) {
             threw = true;
         }

--- a/lib/src/did_methods.rs
+++ b/lib/src/did_methods.rs
@@ -1,0 +1,10 @@
+use did_key::DIDKey;
+use ssi::did::DIDMethods;
+
+lazy_static! {
+    pub static ref DID_METHODS: DIDMethods<'static> = {
+        let mut methods = DIDMethods::default();
+        methods.insert(&DIDKey);
+        methods
+    };
+}

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -22,6 +22,9 @@ pub enum Error {
     Null(NulError),
     Utf8(Utf8Error),
     Borrow(BorrowError),
+    UnableToGenerateDID,
+    UnknownDIDMethod,
+    UnableToGetVerificationMethod,
 
     #[doc(hidden)]
     __Nonexhaustive,
@@ -81,6 +84,9 @@ impl fmt::Display for Error {
             Error::SSI(e) => e.fmt(f),
             Error::Null(e) => e.fmt(f),
             Error::Utf8(e) => e.fmt(f),
+            Error::UnableToGenerateDID => write!(f, "Unable to generate DID"),
+            Error::UnknownDIDMethod => write!(f, "Unknown DID method"),
+            Error::UnableToGetVerificationMethod => write!(f, "Unable to get verification method"),
             _ => unreachable!(),
         }
     }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,9 +1,19 @@
 pub mod c;
+mod did_methods;
 pub mod error;
 pub mod jni;
 
-pub use ssi::error::Error;
+#[macro_use]
+extern crate lazy_static;
+
+pub use crate::did_methods::DID_METHODS;
+pub use crate::error::Error;
+pub use ssi::did::DIDMethod;
+pub use ssi::did::Source;
+pub use ssi::did_resolve::DIDResolver;
 pub use ssi::jwk::JWK;
+pub use ssi::ldp::resolve_key;
+pub use ssi::vc::get_verification_method;
 pub use ssi::vc::Credential as VerifiableCredential;
 pub use ssi::vc::LinkedDataProofOptions;
 pub use ssi::vc::Presentation as VerifiablePresentation;


### PR DESCRIPTION
This adapts DIDKit to have more modular support for DID methods, using the DIDMethod and DIDResolver traits added in https://github.com/spruceid/ssi/pull/67.

Implementations of DIDMethod can be added to the DID_METHODS lazy_static object in `src/did_methods.rs`.

Verify functions will use DID_METHODS as their DID resolver.

Key to DID and key to verification method functions are changed to take a method name option, which indexes into DID_METHODS to select a supported DID method. This is a breaking change for the FFIs, which are updated accordingly. The CLI is updated such that the old way still works but triggers deprecation warnings on standard error.

## API Changes

|Where|                Old                  |                New                                     |
|-----|-------------------------------------|--------------------------------------------------------|
|CLI  |`didkit key-to-did-key`              |`didkit key-to-did key`                                 |
|CLI  |`didkit key-to-verification-method`  |`didkit key-verification-method key`                    |
|Dart |`keyToDIDKey(String key)`            |`keyToDID(String methodName, String key)`               |
|Dart |`keyToVerificationMethod(String key)`|`keyToVerificationMethod(String methodName, String key)`|
|Java |`keyToDID(String jwk)`               |`keyToDID(String methodName, String jwk)`               |
|Java |`keyToVerificationMethod(String jwk)`|`keyToVerificationMethod(String methodName, String jwk)`|
|C    |`const char *didkit_key_to_did(const char *jwk)`|`const char *didkit_key_to_did(const char *method_name, const char *jwk)`|
|C    |`const char *didkit_key_to_verification_method(const char *jwk)`|`const char *didkit_key_to_verification_method(const char *method_name, const char *jwk)`|

The HTTP server does not have key-to-did or key-to-verification-method endpoints does not have a corresponding API change. But it does take keys on the CLI. These are now indexed internally by their hashed public key material rather than by their `did:key` verificationMethod URL. This should allow using keys with DID methods other than did:key.