### PR TITLE
Update vc-http-api

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         repository: spruceid/vc-http-api
         token: ${{ secrets.GH_ACCESS_TOKEN_CEL }}
         path: vc-http-api
-        ref: a7dcc3ed7c96f93059860511d19b384700fb43cc
+        ref: eef5ef2bb2321e4eac3f7e82a2adb7ccd4db1982
 
     - name: Run vc-http-api test suite
       working-directory: vc-http-api/packages/plugfest-2020


### PR DESCRIPTION
This updates the commit used for [vc-http-api](https://github.com/w3c-ccg/vc-http-api/) in CI to point to the latest changes in our fork/branch. The change between the two commits is simply to squash and rebase the changes onto the latest upstream `master` branch.

New commit:
https://github.com/spruceid/vc-http-api/commit/eef5ef2bb2321e4eac3f7e82a2adb7ccd4db1982

Old commit with changes/history:
https://github.com/spruceid/vc-http-api/commits/a7dcc3ed7c96f93059860511d19b384700fb43cc

With this PR merged, I would then delete our fork of vc-http-api, fork the repo publicly, and push our changes back to it. Then we can make PRs to and from it. Deleting and recreating the repo is needed because it was not created as an actual fork but by importing the upstream repo - since there normally is not a way on GitHub to fork a public repo privately.