### PR TITLE
iOS Support

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,4 +17,4 @@ async-trait = "0.1"
 lazy_static = "1.4"
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib", "staticlib", "cdylib"]

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -97,6 +97,28 @@ $(TARGET)/%/release/libdidkit.so: $(RUST_SRC)
 	cargo build --lib --release --target $*
 	$(TOOLCHAIN)/bin/llvm-strip $@
 
+## iOS
+
+.PHONY: install-rustup-ios
+install-rustup-ios:
+	rustup target add \
+		aarch64-apple-ios \
+		x86_64-apple-ios
+
+IOS_LIBS=\
+	$(TARGET)/aarch64-apple-ios/release/libdidkit.a \
+	$(TARGET)/x86_64-apple-ios/release/libdidkit.a
+
+$(TARGET)/test/ios.stamp: $(TARGET)/libdidkit.a | $(TARGET)/test
+	touch $@
+
+$(TARGET)/libdidkit.a: $(IOS_LIBS)
+	lipo -create $^ -output $@
+
+$(TARGET)/%/release/libdidkit.a: $(RUST_SRC)
+	cargo build --lib --release --target $*
+	#$(TOOLCHAIN)/bin/llvm-strip $@
+
 ## Flutter
 
 $(TARGET)/test/flutter.stamp: flutter/lib/didkit.dart flutter/test/didkit_test.dart $(TARGET)/release/libdidkit.so | $(TARGET)/test

--- a/lib/flutter/ios/Classes/DIDKitFlutterPlugin.m
+++ b/lib/flutter/ios/Classes/DIDKitFlutterPlugin.m
@@ -5,4 +5,7 @@
 @implementation DIDKitFlutterPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
 }
++ (void)dummyMethodToEnforceBuilding {
+  didkit_get_version();
+}
 @end

--- a/lib/flutter/ios/didkit.podspec
+++ b/lib/flutter/ios/didkit.podspec
@@ -15,6 +15,8 @@ DIDKit Flutter plugin - iOS implementation
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
+  s.static_framework = true
+  s.vendored_libraries = "**/*.a"
   s.dependency 'Flutter'
   s.platform = :ios, '8.0'
 

--- a/lib/flutter/pubspec.lock
+++ b/lib/flutter/pubspec.lock
@@ -80,7 +80,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.4"
+    version: "1.3.0-nullsafety.3"
   path:
     dependency: transitive
     description:
@@ -106,7 +106,7 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.4"
+    version: "1.10.0-nullsafety.1"
   stream_channel:
     dependency: transitive
     description:
@@ -150,4 +150,4 @@ packages:
     source: hosted
     version: "2.1.0-nullsafety.3"
 sdks:
-  dart: ">=2.10.0-110 <=2.11.0-228.0.dev"
+  dart: ">=2.10.0-110 <2.11.0"


### PR DESCRIPTION
Here are the changes I made to support iOS on Flutter.

- Add `staticlib` to the crate;
- Add `*.a` files to podspec and set `static_framework=true`;
- Add dummy method call so the lib doesn't get excluded;
- Add targets to Makefile to install targets and build and bundle the libs.

[Unfortunately, `rust` has dropped support for `armv7-apple-ios`, `armv7s-apple-ios` and `i386-apple-ios`.](https://blog.rust-lang.org/2020/01/03/reducing-support-for-32-bit-apple-targets.html)
So we can only build and bundle `aarch64-apple-ios` and `x86_64-apple-ios`.