### PR TITLE
Keep ssi features optional

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         repository: spruceid/ssi
         path: ssi
-        ref: d14eadee2c0973c210baadf5ec4f2a20c01412db
+        ref: 594b1965e8ef7a7f0555770b08048728dc803108
 
     - name: Cache Cargo registry and build artifacts
       uses: actions/cache@v2

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 authors = ["Charles E. Lehner <charles.lehner@spruceid.com>"]
 edition = "2018"
 
+[features]
+default = ["ring"]
+ring = ["ssi/ring"]
+
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
@@ -12,6 +16,7 @@ serde_json = "1.0"
 structopt = "0.3"
 async-std = { version = "1.5", features = ["attributes"] }
 did-key = { path = "../../ssi/did-key" }
+ssi = { path = "../../ssi", default-features = false }
 
 [[bin]]
 path = "src/main.rs"

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 authors = ["Charles E. Lehner <charles.lehner@spruceid.com>"]
 edition = "2018"
 
+[features]
+default = ["ring"]
+ring = ["ssi/ring"]
+
 [dependencies]
 didkit = { path = "../lib", features = ["did-web"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
@@ -13,6 +17,7 @@ serde_json = "1.0"
 hyper = { version = "0.14", features = ["server", "client", "http1", "stream"] }
 tower-service = "0.3"
 futures-util = { version = "0.3", default-features = false }
+ssi = { path = "../../ssi", default-features = false }
 
 [dev-dependencies]
 did-key = { path = "../../ssi/did-key" }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -4,9 +4,13 @@ version = "0.1.0"
 authors = ["Charles E. Lehner <charles.lehner@spruceid.com>"]
 edition = "2018"
 
+[features]
+default = ["ring"]
+ring = ["ssi/ring"]
+
 [dependencies]
 #didkit_cbindings = { path = "cbindings/" }
-ssi = { path = "../../ssi" }
+ssi = { path = "../../ssi", default-features = false }
 did-key = { path = "../../ssi/did-key" }
 did-tezos = { path = "../../ssi/did-tezos" }
 did-web = { path = "../../ssi/did-web", optional = true }


### PR DESCRIPTION
Integrate https://github.com/spruceid/ssi/pull/85

This is to allow `didkit-wasm` (#52) to depend on `ssi` without bringing in `ring`, while still using `ring` in the other crates (CLI, HTTP, FFIs), and allowing other dependents to pick their own.