### PR TITLE
Enable http2

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -14,7 +14,7 @@ tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 structopt = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-hyper = { version = "0.14", features = ["server", "client", "http1", "stream"] }
+hyper = { version = "0.14", features = ["server", "client", "http1", "http2", "stream"] }
 tower-service = "0.3"
 futures-util = { version = "0.3", default-features = false }
 ssi = { path = "../../ssi", default-features = false }


### PR DESCRIPTION
We can use hyper v0.14.3 if enabling http2, as described here:
https://github.com/hyperium/hyper/issues/2421

Closes #56, closes #57