### PR TITLE
Add DID Resolution commands and option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         repository: spruceid/ssi
         path: ssi
-        ref: 594b1965e8ef7a7f0555770b08048728dc803108
+        ref: a46a8eaab220684e4b73c5aa025de7b6270340d9
 
     - name: Cache Cargo registry and build artifacts
       uses: actions/cache@v2

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,7 +15,7 @@ didkit = { path = "../lib", features = ["did-web"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 structopt = "0.3"
-async-std = { version = "1.5", features = ["attributes"] }
+async-std = { version = "1.9", features = ["attributes"] }
 did-key = { path = "../../ssi/did-key" }
 ssi = { path = "../../ssi", default-features = false }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,13 +11,19 @@ ring = ["ssi/ring"]
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-didkit = { path = "../lib", features = ["did-web"] }
+didkit = { path = "../lib", features = ["did-web", "http-did"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 structopt = "0.3"
 async-std = { version = "1.9", features = ["attributes"] }
 did-key = { path = "../../ssi/did-key" }
 ssi = { path = "../../ssi", default-features = false }
+
+[dev-dependencies]
+tokio = { version = "1.0", features = ["macros", "process"] }
+hyper = { version = "0.14", features = ["server", "client", "http1", "stream"] }
+percent-encoding = { version = "2.1" }
+futures = "0.3"
 
 [[bin]]
 path = "src/main.rs"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,6 +12,7 @@ ring = ["ssi/ring"]
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 didkit = { path = "../lib", features = ["did-web"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 structopt = "0.3"
 async-std = { version = "1.5", features = ["attributes"] }

--- a/cli/README.md
+++ b/cli/README.md
@@ -121,6 +121,47 @@ Corresponds to [/verify/presentations](https://w3c-ccg.github.io/vc-http-api/#/V
 
 Options and output format are the same as for [didkit vc-verify-credential](#didkit-vc-verify-credential).
 
+### `didkit did-resolve <did>`
+
+Resolve a DID to a DID document, according to [DID Resolution][did-resolution].
+
+#### Options
+- `-m, --with-metadata` - Return a the resolved DID document with resolution metadata and document metadata, in a [DID Resolution Result][did-resolution-result] object.
+- `-i <name=value>` - A [DID Resolution input metadata][did-resolution-input-metadata] property. If `=` is omitted, boolean `true` is used as the value, otherwise, value is a string. May be repeated to add multiple properties. If used multiple times with the same `name`, the values are combined into an array value to form a single property.
+
+#### Output
+Returns the resolved DID document, optionally with metadata.
+
+Without the `-m` option, a representation of the resolved DID document is returned, without document metadata or resolution metadata.
+
+If the `-m` option is used, a DID Resolution Result is returned, which is a JSON object containing the following properties:
+- `didDocument` - the resolved DID document
+- `didResolutionMetadata` - [DID resolution metadata][did-resolution-metadata]
+- `didDocumentMetadata` - [DID document metadata][did-document-metadata]
+- `@context` - JSON-LD context, if using JSON-LD representation.
+
+Exit status is zero on success, and nonzero on failure. On failure, a DID Resolution Result object may still be returned on standard output if the `-m` option is used, where the `error` property of the DID resolution metadata object is set to the error message. If `-m` is not used, the error message is returned on standnard error.
+
+### `didkit did-dereference <did-url>`
+
+Dereference a DID URL to a resource, as in [did-core - DID URL Dereferencing][did-url-dereferencing].
+
+#### Options
+- `-m, --with-metadata` - Return the resulting resource with resolution metadata and document metadata, in a [DID Resolution Result][did-resolution-result] object.
+- `-i <name=value>` - A [DID URL Dereferencing input metadata][did-url-dereferencing-input-metadata] property. If `=` is omitted, boolean `true` is used as the value, otherwise, value is a string. May be repeated to add multiple properties. If used multiple times with the same `name`, the values are combined into an array value to form a single property.
+
+#### Output
+Returns the resource dereferenced from the DID URL, optionally with metadata.
+
+Without the `-m` option, the content resulting from dereferencing is returned, without content metadata or dereferencing metadata.
+
+If the `-m` option is used, a JSON array is returned containing the following three objects:
+- The resolved DID document or other resource corresponding to the dereferenced DID URL
+- [DID dereferencing metadata][did-url-dereferencing-metadata] or [DID resolution metadata][did-resolution-metadata]
+- Content metadata or [DID document metadata][did-document-metadata]
+
+Exit status is zero on success and nonzero on error. On error, if `-m` is used, the error message is returned in the `error` property of the DID dereferencing metadata object on standard output; if `-m` is not used, the error is printed on standard error.
+
 ## Examples
 
 See the included [shell script](tests/example.sh).
@@ -146,3 +187,11 @@ See the included [shell script](tests/example.sh).
 [kty]: https://tools.ietf.org/html/rfc7517#section-4.1
 [kid]: https://tools.ietf.org/html/rfc7517#section-4.5
 [alg]: https://tools.ietf.org/html/rfc7517#section-4.4
+[did-resolution]: https://w3c-ccg.github.io/did-resolution/
+[did-resolution-input-metadata]: https://w3c.github.io/did-core/#did-resolution-input-metadata-properties
+[did-resolution-metadata]: https://w3c.github.io/did-core/#did-resolution-metadata-properties
+[did-document-metadata]: https://w3c.github.io/did-core/#did-document-metadata-properties
+[did-resolution-result]: https://w3c-ccg.github.io/did-resolution/#did-resolution-result
+[did-url-dereferencing]: https://w3c.github.io/did-core/#did-url-dereferencing
+[did-url-dereferencing-metadata]: https://w3c.github.io/did-core/#did-url-dereferencing-metadata-properties
+[did-url-dereferencing-input-metadata]: https://w3c.github.io/did-core/#did-url-dereferencing-input-metadata-properties

--- a/cli/README.md
+++ b/cli/README.md
@@ -48,13 +48,15 @@ The proof type is set automatically based on the key file provided. JWK paramete
 
 #### Options
 
-Options besides `--key-path` correspond to linked data [proof options][] as specified in [ld-proofs][] and [vc-http-api][].
+- `-r, --did-resolver <url>` - [DID resolver HTTP(S) endpoint][did-resolution-https-binding], used for DID resolution and DID URL dereferencing for non-built-in DID Methods. Equivalent to environmental variable `DID_RESOLVER`.
+- `-k, --key-path <key>` (required, conflicts with jwk) - Filename of JWK for signing.
+
+The following options correspond to linked data [proof options][] as specified in [ld-proofs][] and [vc-http-api][]:
 
 - `-C, --challenge <challenge>` - [challenge][] property of the proof
 - `-c, --created <created>` - [created][] property of the proof. ISO8601 datetime. Defaults to the current time.
   time.
 - `-d, --domain <domain>` - [domain][] property of the proof
-- `-k, --key-path <key>` (required, conflicts with jwk) - Filename of JWK for signing.
 - `-j, --jwk <jwk>` (required, conflicts with key-path) - JWK for signing.
 - `-p, --proof-purpose <proof-purpose>` [proofPurpose][] property of the proof.
 - `-v, --verification-method <verification-method>` [verificationMethod][]
@@ -73,7 +75,9 @@ Corresponds to [/verify/credentials](https://w3c-ccg.github.io/vc-http-api/#/Ver
 
 #### Options
 
-Options are linked data [proof options][] as specified in [ld-proofs][] and [vc-http-api][]. If there is more than one proof present, at least one must pass all the requirements passed in the options.
+- `-r, --did-resolver <url>` - [DID resolver HTTP(S) endpoint][did-resolution-https-binding], used for DID resolution and DID URL dereferencing for non-built-in DID Methods. Equivalent to environmental variable `DID_RESOLVER`.
+
+The following options are linked data [proof options][] as specified in [ld-proofs][] and [vc-http-api][]. If there is more than one proof present, at least one must pass all the requirements passed in the options.
 
 - `-C, --challenge <challenge>` - The [challenge][] property of the proof must
   equal this value.
@@ -128,6 +132,7 @@ Resolve a DID to a DID document, according to [DID Resolution][did-resolution].
 #### Options
 - `-m, --with-metadata` - Return a the resolved DID document with resolution metadata and document metadata, in a [DID Resolution Result][did-resolution-result] object.
 - `-i <name=value>` - A [DID Resolution input metadata][did-resolution-input-metadata] property. If `=` is omitted, boolean `true` is used as the value, otherwise, value is a string. May be repeated to add multiple properties. If used multiple times with the same `name`, the values are combined into an array value to form a single property.
+- `-r, --did-resolver <url>` - [DID resolver HTTP(S) endpoint][did-resolution-https-binding], used for DID resolution and DID URL dereferencing for non-built-in DID Methods. Equivalent to environmental variable `DID_RESOLVER`.
 
 #### Output
 Returns the resolved DID document, optionally with metadata.
@@ -149,6 +154,7 @@ Dereference a DID URL to a resource, as in [did-core - DID URL Dereferencing][di
 #### Options
 - `-m, --with-metadata` - Return the resulting resource with resolution metadata and document metadata, in a [DID Resolution Result][did-resolution-result] object.
 - `-i <name=value>` - A [DID URL Dereferencing input metadata][did-url-dereferencing-input-metadata] property. If `=` is omitted, boolean `true` is used as the value, otherwise, value is a string. May be repeated to add multiple properties. If used multiple times with the same `name`, the values are combined into an array value to form a single property.
+- `-r, --did-resolver <url>` - [DID resolver HTTP(S) endpoint][did-resolution-https-binding], used for DID resolution and DID URL dereferencing for non-built-in DID Methods. Equivalent to environmental variable `DID_RESOLVER`.
 
 #### Output
 Returns the resource dereferenced from the DID URL, optionally with metadata.
@@ -195,3 +201,4 @@ See the included [shell script](tests/example.sh).
 [did-url-dereferencing]: https://w3c.github.io/did-core/#did-url-dereferencing
 [did-url-dereferencing-metadata]: https://w3c.github.io/did-core/#did-url-dereferencing-metadata-properties
 [did-url-dereferencing-input-metadata]: https://w3c.github.io/did-core/#did-url-dereferencing-input-metadata-properties
+[did-resolution-https-binding]: https://w3c-ccg.github.io/did-resolution/#bindings-https

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod opts;

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -1,0 +1,20 @@
+use structopt::StructOpt;
+
+use didkit::{HTTPDIDResolver, SeriesResolver, DID_METHODS};
+
+#[derive(StructOpt, Debug, Clone, Default)]
+pub struct ResolverOptions {
+    #[structopt(env, short = "r", long, parse(from_str = HTTPDIDResolver::new))]
+    /// DID Resolver HTTP(S) endpoint, for non-built-in DID methods.
+    pub did_resolver: Option<HTTPDIDResolver>,
+}
+
+impl ResolverOptions {
+    pub fn to_resolver<'a>(&'a self) -> SeriesResolver<'a> {
+        let mut resolvers = vec![DID_METHODS.to_resolver()];
+        if let Some(http_did_resolver) = &self.did_resolver {
+            resolvers.push(http_did_resolver);
+        }
+        SeriesResolver { resolvers }
+    }
+}

--- a/cli/tests/cli.rs
+++ b/cli/tests/cli.rs
@@ -25,7 +25,12 @@ fn issue_verify_credential_presentation() {
 
     // Get verificationMethod for key
     let vm_output = Command::new(BIN)
-        .args(&["key-to-verification-method", "-k", "tests/ed25519-key.jwk"])
+        .args(&[
+            "key-to-verification-method",
+            "key",
+            "-k",
+            "tests/ed25519-key.jwk",
+        ])
         .stderr(Stdio::inherit())
         .output()
         .unwrap();

--- a/cli/tests/example.sh
+++ b/cli/tests/example.sh
@@ -142,4 +142,22 @@ echo 'Verified verifiable presentation:'
 print_json presentation-verify-result.json
 echo
 
+# Resolve a DID.
+if ! didkit did-resolve "$did" > did.json
+then
+	echo 'Unable to resolve DID.'
+	exit 1
+fi
+echo 'Resolved DID to DID document:'
+print_json did.json
+
+# Dereference a DID URL
+if ! didkit did-dereference "$verification_method" > vm.json
+then
+	echo 'Unable to dereference DID URL.'
+	exit 1
+fi
+echo 'Dereferenced DID URL for verification method:'
+print_json vm.json
+
 echo Done

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -14,10 +14,12 @@ tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 structopt = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_urlencoded = "0.7"
 hyper = { version = "0.14", features = ["server", "client", "http1", "http2", "stream"] }
 tower-service = "0.3"
 futures-util = { version = "0.3", default-features = false }
 ssi = { path = "../../ssi", default-features = false }
+percent-encoding = "2.1"
 
 [dev-dependencies]
 did-key = { path = "../../ssi/did-key" }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -9,7 +9,8 @@ default = ["ring"]
 ring = ["ssi/ring"]
 
 [dependencies]
-didkit = { path = "../lib", features = ["did-web"] }
+didkit = { path = "../lib", features = ["did-web", "http-did"] }
+didkit-cli = { path = "../cli" }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 structopt = "0.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/http/README.md
+++ b/http/README.md
@@ -41,23 +41,34 @@ library. Struct `didkit_http::DIDKitHTTPMakeSvc` implements a Tower
 
 ## API
 
+### Verifiable Credentials and Verifiable Presentations
+
 The following routes implement [W3C CCG's VC HTTP API (vc-http-api)][vc-http-api] [v0.0.1][vc-http-api-0.0.1]. POST bodies should be `application/json`. Output will be `application/json` on success; on error it will be either `application/json` or plain text. For more details, see `vc-http-api`.
 
-### POST `/issue/credentials`
+#### POST `/issue/credentials`
 
 Issue a verifiable credential. The server uses its configured key and the given linked data proof options to generate a proof and append it to the given credential. On success, the resulting verifiable credential is returned, with HTTP status 201.
 
-### POST `/verify/credentials`
+#### POST `/verify/credentials`
 
 Verify a verifiable credential. The server verifies the given credential with the given linked data proof options. To successfully verify, the credential must contain at least one proof that verifies successfully. Verification results include a list of checks performed, warnings that should be flagged to the user, and errors encountered. On success, the errors list will be empty, and the HTTP status code will be 200.
 
-### POST `/prove/presentations`
+#### POST `/prove/presentations`
 
 Create a verifiable presentation. Given a presentation and linked data proof options, the server uses its key to generate a proof and append it to the presentation. On success, returns the verifiable presentation and HTTP status 201.
 
-### POST `/verify/presentations`
+#### POST `/verify/presentations`
 
 Verify a verifiable presentation using the given proof options. Returns a verification result. HTTP status 200 indicates successful verification.
 
+### DIDs (Decentralized Identifiers)
+
+The following route implements the [DID Resolution HTTP(S) Binding][did-http].
+
+#### POST `/identifiers/<uri>`
+
+Resolve a DID to a DID document, or dereference a DID URL to a resource. Parameter `<uri>` is the DID or DID URL to resolve/dereference.
+
+[did-http]: https://w3c-ccg.github.io/did-resolution/#bindings-https
 [vc-http-api]: https://w3c-ccg.github.io/vc-http-api/
 [vc-http-api-0.0.1]: https://github.com/w3c-ccg/vc-http-api/pull/72

--- a/http/README.md
+++ b/http/README.md
@@ -27,6 +27,7 @@ and runs until interrupted.
 - `-k, --key <key>`   - Filename of a JWK to use for issuing credentials and
   presentations.
 - `-j, --jwk <jwk>`   - JWK to use for issuing credentials and presentations.
+- `-r, --did-resolver <url>` - [DID resolver HTTP(S) endpoint][did-resolution-https-binding] URL to use for resolving DIDs and dereferencing DID URLs that the built-in resolver does not support. Equivalent to environmental variable `DID_RESOLVER`.
 
 #### Issuer keys
 
@@ -72,3 +73,4 @@ Resolve a DID to a DID document, or dereference a DID URL to a resource. Paramet
 [did-http]: https://w3c-ccg.github.io/did-resolution/#bindings-https
 [vc-http-api]: https://w3c-ccg.github.io/vc-http-api/
 [vc-http-api-0.0.1]: https://github.com/w3c-ccg/vc-http-api/pull/72
+[did-resolution-https-binding]: https://w3c-ccg.github.io/did-resolution/#bindings-https

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -520,6 +520,9 @@ impl DIDKitHTTPSvc {
                     };
                     body = Body::from(object_data);
                 }
+                Content::Data(data) => {
+                    body = Body::from(data);
+                }
                 Content::Null => {}
             };
             let response = Response::from_parts(parts, body);

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -6,6 +6,7 @@ use hyper::Server;
 use structopt::StructOpt;
 
 use didkit::JWK;
+use didkit_cli::opts::ResolverOptions;
 use didkit_http::DIDKitHTTPMakeSvc;
 use didkit_http::Error;
 
@@ -20,6 +21,8 @@ pub struct DIDKitHttpOpts {
     /// JWK to use for issuing
     #[structopt(flatten)]
     key: KeyArg,
+    #[structopt(flatten)]
+    resolver_options: ResolverOptions,
 }
 
 #[derive(StructOpt, Debug)]
@@ -59,7 +62,7 @@ async fn main() -> Result<(), Error> {
     let opt = DIDKitHttpOpts::from_args();
 
     let keys = opt.key.get_jwks();
-    let makesvc = DIDKitHTTPMakeSvc::new(keys);
+    let makesvc = DIDKitHTTPMakeSvc::new(keys, opt.resolver_options);
     let host = opt.host.unwrap_or([127, 0, 0, 1].into());
     let addr = (host, opt.port.unwrap_or(0)).into();
 

--- a/http/tests/example.sh
+++ b/http/tests/example.sh
@@ -183,4 +183,28 @@ echo 'Verified verifiable presentation:'
 print_json presentation-verify-result.json
 echo
 
+# Resolve a DID to a DID Document.
+if ! curl -fsS "$didkit_url/identifiers/$did" \
+	-o did.json
+then
+	echo 'Unable to resolve DID.'
+	exit 1
+fi
+echo 'Resolved DID to DID document:'
+print_json did.json
+echo
+
+# Dereference a DID URL.
+# URL-encode verificationMethod DID URL
+vm_enc=$(printf %s "$verification_method" | sed 's/#/%23/g')
+if ! curl -fsS "$didkit_url/identifiers/$vm_enc" \
+	-o vm.json
+then
+	echo 'Unable to resolve DID.'
+	exit 1
+fi
+echo 'Dereferenced DID URL for verification method:'
+print_json vm.json
+echo
+
 echo Done

--- a/http/tests/main.rs
+++ b/http/tests/main.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use didkit::{Document, JWK};
+use didkit_cli::opts::ResolverOptions;
 use didkit_http::DIDKitHTTPMakeSvc;
 use didkit_http::VerifyCredentialResponse;
 use didkit_http::VerifyPresentationResponse;
@@ -49,7 +50,8 @@ fn serve(other_keys: Option<Vec<JWK>>) -> (String, impl FnOnce() -> ()) {
     if let Some(mut other_keys) = other_keys {
         keys.append(&mut other_keys);
     }
-    let makesvc = DIDKitHTTPMakeSvc::new(keys);
+    let resolver_options = ResolverOptions::default();
+    let makesvc = DIDKitHTTPMakeSvc::new(keys, resolver_options);
     let addr = ([127, 0, 0, 1], 0).into();
     let server = Server::bind(&addr).serve(makesvc);
     let url = "http://".to_string() + &server.local_addr().to_string();

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 default = ["ring"]
 ring = ["ssi/ring"]
 wasm = []
+http-did = ["ssi/http-did"]
 
 [dependencies]
 #didkit_cbindings = { path = "cbindings/" }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,7 +17,7 @@ did-tezos = { path = "../../ssi/did-tezos" }
 did-web = { path = "../../ssi/did-web", optional = true }
 serde_json = "1.0"
 jni = "0.17"
-async-std = "1.8"
+async-std = "1.9"
 async-trait = "0.1"
 lazy_static = "1.4"
 

--- a/lib/c/test.c
+++ b/lib/c/test.c
@@ -84,6 +84,19 @@ int main() {
 
     didkit_free_string(vp);
     didkit_free_string(vc);
+
+    // Resolve DID
+    const char *did_doc = didkit_did_resolve(did, NULL);
+    if (did_doc == NULL) errx(1, "resolve DID: %s", didkit_error_message());
+    if (strstr(did_doc, "\"didDocument\":{") == NULL) errx(1, "DID resolution result: %s", did_doc);
+    didkit_free_string(did_doc);
+
+    // Dereference DID URL
+    const char *result = didkit_did_url_dereference(verification_method, NULL);
+    if (result == NULL) errx(1, "Dereference DID URL: %s", didkit_error_message());
+    if (strncmp(result, "[{", 2) != 0) errx(1, "DID dereferencing result: %s", result);
+    didkit_free_string(result);
+
     didkit_free_string(verification_method);
     didkit_free_string(did);
     didkit_free_string(key);

--- a/lib/flutter/lib/didkit.dart
+++ b/lib/flutter/lib/didkit.dart
@@ -39,6 +39,12 @@ final issue_presentation = lib
 final verify_presentation = lib
   .lookupFunction<Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>), Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>)>('didkit_vc_verify_presentation');
 
+final resolve_did = lib
+  .lookupFunction<Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>), Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>)>('didkit_did_resolve');
+
+final dereference_did_url = lib
+  .lookupFunction<Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>), Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>)>('didkit_did_url_dereference');
+
 final free_string = lib
   .lookupFunction<Void Function(Pointer<Utf8>), void Function(Pointer<Utf8>)>('didkit_free_string');
 
@@ -128,6 +134,22 @@ class DIDKit {
 
   static String verifyPresentation(String presentation, String options) {
     final result = verify_presentation(Utf8.toUtf8(presentation), Utf8.toUtf8(options));
+    if (result.address == nullptr.address) throw lastError();
+    final result_string = Utf8.fromUtf8(result);
+    free_string(result);
+    return result_string;
+  }
+
+  static String resolveDID(String did, String inputMetadata) {
+    final result = resolve_did(Utf8.toUtf8(did), Utf8.toUtf8(inputMetadata));
+    if (result.address == nullptr.address) throw lastError();
+    final result_string = Utf8.fromUtf8(result);
+    free_string(result);
+    return result_string;
+  }
+
+  static String dereferenceDIDURL(String didUrl, String inputMetadata) {
+    final result = dereference_did_url(Utf8.toUtf8(didUrl), Utf8.toUtf8(inputMetadata));
     if (result.address == nullptr.address) throw lastError();
     final result_string = Utf8.fromUtf8(result);
     free_string(result);

--- a/lib/flutter/test/didkit_test.dart
+++ b/lib/flutter/test/didkit_test.dart
@@ -83,4 +83,18 @@ void main() {
     final verifyResult = jsonDecode(DIDKit.verifyPresentation(vc, jsonEncode(verifyOptions)));
     expect(verifyResult['errors'], isEmpty);
   });
+
+  test('resolveDID', () async {
+    final key = DIDKit.generateEd25519Key();
+    final did = DIDKit.keyToDID("key", key);
+    final resolutionResult = jsonDecode(DIDKit.resolveDID(did, "{}"));
+    expect(resolutionResult['didDocument'], isNotEmpty);
+  });
+
+  test('dereferenceDIDURL', () async {
+    final key = DIDKit.generateEd25519Key();
+    final verificationMethod = DIDKit.keyToVerificationMethod("key", key);
+    final derefResult = jsonDecode(DIDKit.dereferenceDIDURL(verificationMethod, "{}"));
+    expect(derefResult, isList);
+  });
 }

--- a/lib/java/main/com/spruceid/DIDKit.java
+++ b/lib/java/main/com/spruceid/DIDKit.java
@@ -11,6 +11,8 @@ public class DIDKit {
     public static native String verifyCredential(String verifiableCredential, String linkedDataProofOptions);
     public static native String issuePresentation(String presentation, String linkedDataProofOptions, String key) throws DIDKitException;
     public static native String verifyPresentation(String verifiablePresentation, String linkedDataProofOptions);
+    public static native String resolveDID(String did, String inputMetadata);
+    public static native String dereferenceDIDURL(String didUrl, String inputMetadata);
 
     static {
         System.loadLibrary("didkit");

--- a/lib/java/test/com/spruceid/DIDKitTest.java
+++ b/lib/java/test/com/spruceid/DIDKitTest.java
@@ -68,5 +68,13 @@ class DIDKitTest {
             + "}";
         String vpResult = DIDKit.verifyPresentation(vp, vpVerifyOptions);
         assert vpResult.contains("\"errors\":[]");
+
+        // Resolve DID
+        String resolutionResult = DIDKit.resolveDID(did, "{}");
+        assert vpResult.contains("\"didDocument\":{");
+
+        // Dereference DID URL
+        String dereferencingResult = DIDKit.dereferenceDIDURL(verificationMethod, "{}");
+        assert vpResult.startsWith("[{");
     }
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -11,9 +11,12 @@ extern crate lazy_static;
 pub use crate::did_methods::DID_METHODS;
 pub use crate::error::Error;
 pub use ssi::did::{DIDMethod, Document, Source};
+#[cfg(feature = "http-did")]
+pub use ssi::did_resolve::HTTPDIDResolver;
 pub use ssi::did_resolve::{
-    dereference, Content, ContentMetadata, DIDResolver, DereferencingInputMetadata, Metadata,
-    ResolutionInputMetadata, ResolutionResult,
+    dereference, Content, ContentMetadata, DIDResolver, DereferencingInputMetadata,
+    DocumentMetadata, Metadata, ResolutionInputMetadata, ResolutionMetadata, ResolutionResult,
+    SeriesResolver,
 };
 pub use ssi::jwk::JWK;
 pub use ssi::ldp::resolve_key;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -10,9 +10,11 @@ extern crate lazy_static;
 
 pub use crate::did_methods::DID_METHODS;
 pub use crate::error::Error;
-pub use ssi::did::DIDMethod;
-pub use ssi::did::Source;
-pub use ssi::did_resolve::DIDResolver;
+pub use ssi::did::{DIDMethod, Document, Source};
+pub use ssi::did_resolve::{
+    dereference, Content, ContentMetadata, DIDResolver, DereferencingInputMetadata, Metadata,
+    ResolutionInputMetadata, ResolutionResult,
+};
 pub use ssi::jwk::JWK;
 pub use ssi::ldp::resolve_key;
 pub use ssi::vc::get_verification_method;


### PR DESCRIPTION
New commands, with corresponding FFI functions:
- `did-resolve` - [Resolve a DID to a DID document](https://w3c-ccg.github.io/did-resolution/#resolving).
- `did-dereference` - [Dereference a DID URL to a resource](https://w3c-ccg.github.io/did-resolution/#dereferencing).

New HTTP route:
- `/identifiers/<uri>` - Resolve a DID or dereference a DID URL, according to the [DID Resolution HTTP(S) Binding][did-resolution-https-binding].

New CLI option for `didkit-cli` and `didkit-http`:
- `-r` (`--did-resolver`) - URL of a [DID resolver HTTP(S) endpoint]. Used as a fallback resolver to resolver DIDs and dereference DID URLs for DID methods not built-in to DIDKit.

The DID Resolution HTTP(S) Binding as implemented here is compatible with the [Universal Resolver](https://github.com/decentralized-identity/universal-resolver/).

[did-resolution-https-binding]: https://w3c-ccg.github.io/did-resolution/#bindings-https

Depends on https://github.com/spruceid/ssi/pull/87

Fixes #40