### PR TITLE
Flutter Library Updates

### DIFF
--- a/lib/flutter/.gitignore
+++ b/lib/flutter/.gitignore
@@ -1,7 +1,43 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
 .DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
 .dart_tool/
-
+.flutter-plugins
+.flutter-plugins-dependencies
 .packages
+.pub-cache/
 .pub/
+/build/
 
-build/
+# Web related
+lib/generated_plugin_registrant.dart
+
+# Symbolication related
+app.*.symbols
+
+# Obfuscation related
+app.*.map.json
+
+# Exceptions to above rules.
+!/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages

--- a/lib/flutter/analysis_options.yaml
+++ b/lib/flutter/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:pedantic/analysis_options.yaml

--- a/lib/flutter/lib/didkit.dart
+++ b/lib/flutter/lib/didkit.dart
@@ -1,4 +1,4 @@
-library DIDKit;
+library didkit;
 
 import 'dart:ffi';
 import 'dart:io';
@@ -6,7 +6,7 @@ import 'package:ffi/ffi.dart';
 
 // TODO: support macOS, Windows
 final DynamicLibrary lib = Platform.isAndroid || Platform.isLinux
-  ? DynamicLibrary.open("libdidkit.so")
+  ? DynamicLibrary.open('libdidkit.so')
   : DynamicLibrary.process();
 
 final get_version = lib
@@ -46,8 +46,10 @@ class DIDKitException implements Exception {
   int code;
   String message;
   DIDKitException(this.code, this.message);
+
+  @override
   String toString() {
-    return "DIDKitException ($code): $message";
+    return 'DIDKitException ($code): $message';
   }
 }
 
@@ -55,10 +57,10 @@ DIDKitException lastError() {
   final code = get_error_code();
   final message_utf8 = get_error_message();
   final message_string = message_utf8.address == nullptr.address
-    ? "Unable to get error message"
+    ? 'Unable to get error message'
     : Utf8.fromUtf8(message_utf8);
 
-  return new DIDKitException(code, message_string);
+  return DIDKitException(code, message_string);
 }
 
 class DIDKit {
@@ -77,7 +79,7 @@ class DIDKit {
 
   @Deprecated('Use [keyToDID]')
   static String keyToDIDKey(String key) {
-    final did_key = key_to_did(Utf8.toUtf8("key"), Utf8.toUtf8(key));
+    final did_key = key_to_did(Utf8.toUtf8('key'), Utf8.toUtf8(key));
     if (did_key.address == nullptr.address) throw lastError();
     final did_key_string = Utf8.fromUtf8(did_key);
     free_string(did_key);

--- a/lib/flutter/pubspec.lock
+++ b/lib/flutter/pubspec.lock
@@ -7,56 +7,56 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0-nullsafety.3"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0-nullsafety.3"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0-nullsafety.5"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0-nullsafety.3"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0-nullsafety.5"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   ffi:
     dependency: "direct main"
     description:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.3.0-nullsafety.1"
   flutter:
     dependency: transitive
     description: flutter
@@ -73,21 +73,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10-nullsafety.3"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0-nullsafety.6"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0-nullsafety.3"
+  pedantic:
+    dependency: "direct dev"
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.10.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -99,55 +106,55 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0-nullsafety.4"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0-nullsafety.6"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0-nullsafety.3"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0-nullsafety.3"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19-nullsafety.6"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0-nullsafety.5"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0-nullsafety.5"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
+  dart: ">=2.12.0-259.8.beta <3.0.0"

--- a/lib/flutter/pubspec.yaml
+++ b/lib/flutter/pubspec.yaml
@@ -5,14 +5,15 @@ author: Charles E. Lehner <charles.lehner@spruceid.com>
 homepage: https://github.com/spruceid/didkit/tree/main/lib/flutter
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.11.0 <3.0.0"
 
 dependencies:
-  ffi: ^0.1.3
+  ffi: ^0.3.0-nullsafety.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  pedantic: ^1.10.0
 
 flutter:
   plugin:

--- a/lib/flutter/test/didkit_test.dart
+++ b/lib/flutter/test/didkit_test.dart
@@ -11,7 +11,7 @@ void main() {
   });
 
   test('Exception', () async {
-    expect(() => DIDKit.issuePresentation("", "", ""), throwsA(isInstanceOf<DIDKitException>()));
+    expect(() => DIDKit.issuePresentation('', '', ''), throwsA(isInstanceOf<DIDKitException>()));
   });
 
   test('generateEd25519Key', () async {
@@ -20,32 +20,32 @@ void main() {
 
   test('keyToDID', () async {
     final key = DIDKit.generateEd25519Key();
-    final did = DIDKit.keyToDID("key", key);
+    final did = DIDKit.keyToDID('key', key);
     expect(did, isInstanceOf<String>());
   });
 
   test('issueCredential, verifyCredential', () async {
     final key = DIDKit.generateEd25519Key();
-    final did = DIDKit.keyToDID("key", key);
-    final verificationMethod = DIDKit.keyToVerificationMethod("key", key);
+    final did = DIDKit.keyToDID('key', key);
+    final verificationMethod = DIDKit.keyToVerificationMethod('key', key);
     final options = {
-        "proofPurpose": "assertionMethod",
-        "verificationMethod": verificationMethod
+        'proofPurpose': 'assertionMethod',
+        'verificationMethod': verificationMethod
     };
     final credential = {
-        "@context": "https://www.w3.org/2018/credentials/v1",
-        "id": "http://example.org/credentials/3731",
-        "type": ["VerifiableCredential"],
-        "issuer": did,
-        "issuanceDate": "2020-08-19T21:41:50Z",
-        "credentialSubject": {
-           "id": "did:example:d23dd687a7dc6787646f2eb98d0"
+        '@context': 'https://www.w3.org/2018/credentials/v1',
+        'id': 'http://example.org/credentials/3731',
+        'type': ['VerifiableCredential'],
+        'issuer': did,
+        'issuanceDate': '2020-08-19T21:41:50Z',
+        'credentialSubject': {
+           'id': 'did:example:d23dd687a7dc6787646f2eb98d0'
         }
     };
     final vc = DIDKit.issueCredential(jsonEncode(credential), jsonEncode(options), key);
 
     final verifyOptions = {
-        "proofPurpose": "assertionMethod"
+        'proofPurpose': 'assertionMethod'
     };
     final verifyResult = jsonDecode(DIDKit.verifyCredential(vc, jsonEncode(verifyOptions)));
     expect(verifyResult['errors'], isEmpty);
@@ -53,35 +53,34 @@ void main() {
 
   test('issuePresentation, verifyPresentation', () async {
     final key = DIDKit.generateEd25519Key();
-    final did = DIDKit.keyToDID("key", key);
-    final verificationMethod = DIDKit.keyToVerificationMethod("key", key);
+    final did = DIDKit.keyToDID('key', key);
+    final verificationMethod = DIDKit.keyToVerificationMethod('key', key);
     final options = {
-        "proofPurpose": "authentication",
-        "verificationMethod": verificationMethod
+        'proofPurpose': 'authentication',
+        'verificationMethod': verificationMethod
     };
     final presentation = {
-        "@context": ["https://www.w3.org/2018/credentials/v1"],
-        "id": "http://example.org/presentations/3731",
-        "type": ["VerifiablePresentation"],
-        "holder": did,
-        "verifiableCredential": {
-            "@context": "https://www.w3.org/2018/credentials/v1",
-            "id": "http://example.org/credentials/3731",
-            "type": ["VerifiableCredential"],
-            "issuer": "did:example:30e07a529f32d234f6181736bd3",
-            "issuanceDate": "2020-08-19T21:41:50Z",
-            "credentialSubject": {
-                "id": "did:example:d23dd687a7dc6787646f2eb98d0"
+        '@context': ['https://www.w3.org/2018/credentials/v1'],
+        'id': 'http://example.org/presentations/3731',
+        'type': ['VerifiablePresentation'],
+        'holder': did,
+        'verifiableCredential': {
+            '@context': 'https://www.w3.org/2018/credentials/v1',
+            'id': 'http://example.org/credentials/3731',
+            'type': ['VerifiableCredential'],
+            'issuer': 'did:example:30e07a529f32d234f6181736bd3',
+            'issuanceDate': '2020-08-19T21:41:50Z',
+            'credentialSubject': {
+                'id': 'did:example:d23dd687a7dc6787646f2eb98d0'
             }
         }
     };
     final vc = DIDKit.issuePresentation(jsonEncode(presentation), jsonEncode(options), key);
 
     final verifyOptions = {
-        "proofPurpose": "authentication"
+        'proofPurpose': 'authentication'
     };
     final verifyResult = jsonDecode(DIDKit.verifyPresentation(vc, jsonEncode(verifyOptions)));
     expect(verifyResult['errors'], isEmpty);
   });
-
 }


### PR DESCRIPTION
I was updating dependencies on Credible in preparation for the upcoming Dart [nullsafety](https://dart.dev/null-safety/migration-guide) and ended up having to also update the `ffi` version on the library to match. I took the liberty to also add the same lint options I'm using on Credible, update .gitignore, and remove the default example.