### PR TITLE
Use Flutter dev channel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,8 @@ jobs:
 
     - name: Install Flutter
       uses: subosito/flutter-action@v1
+      with:
+        channel: 'dev'
 
     - name: Opt out of Dart/Flutter analytics
       run: |


### PR DESCRIPTION
Attempt to fix build error in CI:

> Because didkit requires SDK version >=2.11.0 <3.0.0, version solving failed.

> The current Dart SDK version is 2.10.5.

https://github.com/spruceid/didkit/runs/1856876167#step:24:26