### PR TITLE
Exclude didkit-wasm in build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ git clone https://github.com/spruceid/ssi ../ssi --recurse-submodules
 
 Build DIDKit using [Cargo][]:
 ```sh
-$ cargo build
+$ cargo build --workspace --exclude didkit-wasm
 ```
 That will give you the DIDKit CLI and HTTP server executables located at
 `target/debug/didkit` and `target/debug/didkit-http`, respectively. You can also build and install DIDKit's components separately. Building the FFI libraries will require additional dependencies. See the corresponding readmes linked below for more info.


### PR DESCRIPTION
`cargo build` in the repo root directory builds all the packages in the workspace. Since #55 this results in enabling conflicting features for cryptographic backends in `ssi`. This PR updates the readme to say to build the workspace excluding the `didkit-wasm` crate - so that the `ssi` features needed for WASM (which conflict with the default `ssi` features) are not enabled at the same time.

I'm also open to suggestions on other ways to make this better.