### PR TITLE
Set default workspace members excluding WASM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,10 @@ jobs:
         default: true
 
     - name: Build
-      run: cargo build --verbose --workspace --exclude didkit-wasm
+      run: cargo build --verbose
 
     - name: Test
-      run: cargo build --verbose --workspace --exclude didkit-wasm
+      run: cargo test --verbose
 
     - name: Test CLI
       run: cli/tests/example.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,11 @@ members = [
   "lib/node/native",
   "lib/wasm"
 ]
+
+default-members = [
+  "http",
+  "cli",
+  "lib",
+  "lib/cbindings",
+  "lib/node/native"
+]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ git clone https://github.com/spruceid/ssi ../ssi --recurse-submodules
 
 Build DIDKit using [Cargo][]:
 ```sh
-$ cargo build --workspace --exclude didkit-wasm
+$ cargo build
 ```
 That will give you the DIDKit CLI and HTTP server executables located at
 `target/debug/didkit` and `target/debug/didkit-http`, respectively. You can also build and install DIDKit's components separately. Building the FFI libraries will require additional dependencies. See the corresponding readmes linked below for more info.


### PR DESCRIPTION
As suggested by @theosirian in https://github.com/spruceid/didkit/pull/62#issuecomment-775938615: this sets the `default-members` workspace config property to the existing workspace members except for `didkit-wasm`. This enables using `cargo build` in the repo root directory - a common command for a user to tun - without causing incompatible `ssi` features to be enabled. CI is also updated to use
`cargo build --verbose`. Fixes https://github.com/spruceid/didkit/issues/63