### PR TITLE
Remove node build from default-members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,4 @@ default-members = [
   "cli",
   "lib",
   "lib/cbindings",
-  "lib/node/native"
 ]


### PR DESCRIPTION
I am removing this member to strip external nodejs dependencies from the default `cargo build` command.