### PR TITLE
Remove obsolete access token

### DIFF
--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -20,7 +20,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: spruceid/ssi
-        token: ${{ secrets.GH_ACCESS_TOKEN_CEL }}
         path: didkit/ssi
 
     - name: Build and push CLI


### PR DESCRIPTION
This should have been included in #54.

This should fix the build error seen in https://github.com/spruceid/didkit/runs/1865533845 since I removed the token from the repo settings.