### PR TITLE
Use tokio runtime

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,7 +15,6 @@ didkit = { path = "../lib", features = ["did-web", "http-did"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 structopt = "0.3"
-async-std = { version = "1.9", features = ["attributes"] }
 did-key = { path = "../../ssi/did-key" }
 ssi = { path = "../../ssi", default-features = false }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,13 +8,13 @@ use chrono::prelude::*;
 use serde::Serialize;
 use serde_json::Value;
 use structopt::{clap::AppSettings, clap::ArgGroup, StructOpt};
-use tokio::runtime::Runtime;
 
 use did_key::DIDKey;
 use didkit::{
-    dereference, get_verification_method, DIDMethod, DIDResolver, DereferencingInputMetadata,
-    Error, LinkedDataProofOptions, Metadata, ProofPurpose, ResolutionInputMetadata,
-    ResolutionResult, Source, VerifiableCredential, VerifiablePresentation, DID_METHODS, JWK,
+    dereference, get_verification_method, runtime, DIDMethod, DIDResolver,
+    DereferencingInputMetadata, Error, LinkedDataProofOptions, Metadata, ProofPurpose,
+    ResolutionInputMetadata, ResolutionResult, Source, VerifiableCredential,
+    VerifiablePresentation, DID_METHODS, JWK,
 };
 use didkit_cli::opts::ResolverOptions;
 
@@ -267,7 +267,7 @@ mod tests {
 }
 
 fn main() {
-    let rt = Runtime::new().unwrap();
+    let rt = runtime::get().unwrap();
     let opt = DIDKit::from_args();
     match opt {
         DIDKit::GenerateEd25519Key => {

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -18,9 +18,9 @@ did-tezos = { path = "../../ssi/did-tezos" }
 did-web = { path = "../../ssi/did-web", optional = true }
 serde_json = "1.0"
 jni = "0.17"
-async-std = "1.9"
 async-trait = "0.1"
 lazy_static = "1.4"
+tokio = { version = "1.0", features = ["rt-multi-thread"] }
 
 [lib]
 crate-type = ["lib", "staticlib", "cdylib"]

--- a/lib/node/native/Cargo.toml
+++ b/lib/node/native/Cargo.toml
@@ -19,4 +19,4 @@ didkit = { path = "../../", default-features = false }
 neon = "0.6.0"
 neon-serde = { git = "https://github.com/theosirian/neon-serde" }
 serde = "1.0"
-async-std = "1.8"
+tokio = { version = "1.0", features = ["rt-multi-thread"] }

--- a/lib/node/native/src/error.rs
+++ b/lib/node/native/src/error.rs
@@ -1,6 +1,7 @@
 use didkit::error::Error as DIDKitError;
 use neon_serde::errors::Error as NeonSerdeError;
 use ssi::error::Error as SsiError;
+use std::io::Error as IOError;
 
 pub struct Error(pub String);
 
@@ -18,6 +19,12 @@ impl From<DIDKitError> for self::Error {
 
 impl From<NeonSerdeError> for self::Error {
     fn from(err: NeonSerdeError) -> self::Error {
+        self::Error(err.to_string())
+    }
+}
+
+impl From<IOError> for self::Error {
+    fn from(err: IOError) -> self::Error {
         self::Error(err.to_string())
     }
 }

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -7,6 +7,7 @@ use std::ptr;
 
 use serde_json::Error as JSONError;
 use ssi::error::Error as SSIError;
+use std::io::Error as IOError;
 use std::str::Utf8Error;
 
 static UNKNOWN_ERROR: &str = "Unable to create error string\0";
@@ -22,6 +23,7 @@ pub enum Error {
     Null(NulError),
     Utf8(Utf8Error),
     Borrow(BorrowError),
+    IO(IOError),
     UnableToGenerateDID,
     UnknownDIDMethod,
     UnableToGetVerificationMethod,
@@ -113,6 +115,12 @@ impl From<NulError> for Error {
 impl From<Utf8Error> for Error {
     fn from(err: Utf8Error) -> Error {
         Error::Utf8(err)
+    }
+}
+
+impl From<IOError> for Error {
+    fn from(err: IOError) -> Error {
+        Error::IO(err)
     }
 }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -4,6 +4,8 @@ mod did_methods;
 pub mod error;
 #[cfg(not(feature = "wasm"))]
 pub mod jni;
+#[cfg(not(feature = "wasm"))]
+pub mod runtime;
 
 #[macro_use]
 extern crate lazy_static;

--- a/lib/src/runtime.rs
+++ b/lib/src/runtime.rs
@@ -1,0 +1,10 @@
+use tokio::runtime::{Builder, Runtime};
+
+use crate::error::Error;
+
+/// Get a [Tokio runtime] for the current thread.
+/// [Tokio runtime]: https://docs.rs/tokio/1.2.0/tokio/runtime/struct.Runtime.html
+pub fn get() -> Result<Runtime, Error> {
+    let rt = Builder::new_current_thread().enable_all().build()?;
+    Ok(rt)
+}

--- a/lib/wasm/Cargo.toml
+++ b/lib/wasm/Cargo.toml
@@ -10,7 +10,6 @@ wasm-bindgen-futures = "0.4"
 serde_json = "1.0"
 js-sys = "0.3"
 getrandom = { version = "0.2", features = ["js"] }
-async-std = "1.8"
 rand = { version = "0.7", features = ["wasm-bindgen"] }
 chrono = { version = "0.4", features = ["wasmbind"] }
 


### PR DESCRIPTION
Using `hyper` for HTTP(S) requires a [`tokio` Runtime](https://docs.rs/tokio/1.2.0/tokio/runtime/struct.Runtime.html).

This PR updates the FFI code to set up a Tokio runtime for FFI calls and use the runtime's [`block_on`](https://docs.rs/tokio/1.2.0/tokio/runtime/struct.Runtime.html#method.block_on) function instead of `async-std`'s [`block_on`](https://docs.rs/async-std/1.9.0/async_std/task/fn.block_on.html). This is needed for resolving `did:web` DIDs since that uses `hyper`, which would otherwise `panic` about not being run in a Tokio runtime.

For performance reasons, I set the FFI functions to use Tokio's [current-thread scheduler](https://docs.rs/tokio/1.2.0/tokio/runtime/struct.Runtime.html#current-thread-scheduler), to avoid spawning threads on each call. If we eventually need the multi-threaded scheduler, we might want to try to create one lazily and reuse it, like by storing it in static a RefCell. (https://docs.rs/tokio/1.2.0/tokio/attr.main.html says: "If the function is called often, it is preferable to create the runtime using the runtime builder so the runtime can be reused across calls.").

Using a runtime is added to the C FFI, JNI and Node bindings. The CLI already uses one (since https://github.com/spruceid/didkit/pull/36) but I have updated it to be consistent with the others using the current-thread scheduler (since it just does one operation per process run). `didkit-http` already has a runtime since it uses `#[tokio::main]` (multi-thread scheduler). The WASM package doesn't need it since it converts Futures to Promises with [wasm-bindgen-futures](https://docs.rs/wasm-bindgen-futures/0.4.20/wasm_bindgen_futures/) instead of running them with `block_on`.