### PR TITLE
[WIP] Add GenerateEd25519KeyFromSecret (c,java,flutter,cli)

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Charles E. Lehner <charles.lehner@spruceid.com>"]
 edition = "2018"
 
 [features]
-default = ["ring"]
+default = []
 ring = ["ssi/ring"]
 
 [dependencies]
@@ -17,7 +17,7 @@ serde_json = "1.0"
 structopt = "0.3"
 async-std = { version = "1.9", features = ["attributes"] }
 did-key = { path = "../../ssi/did-key" }
-ssi = { path = "../../ssi", default-features = false }
+ssi = { path = "../../ssi", default-features = false, features = ["ed25519-dalek", "sha2", "rsa", "rand"] }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "process"] }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -22,6 +22,13 @@ use didkit_cli::opts::ResolverOptions;
 pub enum DIDKit {
     /// Generate and output a Ed25519 keypair in JWK format
     GenerateEd25519Key,
+
+    /// Generate and output a Ed25519 keypair in JWK format from a secret
+    GenerateEd25519KeyFromSecret {
+        /// 32 byte string.
+        secret: String,
+    },
+
     /// Output a did:key DID for a JWK. Deprecated in favor of key-to-did.
     #[structopt(setting = AppSettings::Hidden)]
     KeyToDIDKey {
@@ -272,6 +279,12 @@ fn main() {
     match opt {
         DIDKit::GenerateEd25519Key => {
             let jwk = JWK::generate_ed25519().unwrap();
+            let jwk_str = serde_json::to_string(&jwk).unwrap();
+            println!("{}", jwk_str);
+        }
+
+        DIDKit::GenerateEd25519KeyFromSecret { secret } => {
+            let jwk = JWK::generate_ed25519_from_secret(&secret).unwrap();
             let jwk_str = serde_json::to_string(&jwk).unwrap();
             println!("{}", jwk_str);
         }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Charles E. Lehner <charles.lehner@spruceid.com>"]
 edition = "2018"
 
 [features]
-default = ["ring"]
+default = []
 ring = ["ssi/ring"]
 
 [dependencies]
@@ -19,7 +19,7 @@ serde_urlencoded = "0.7"
 hyper = { version = "0.14", features = ["server", "client", "http1", "http2", "stream"] }
 tower-service = "0.3"
 futures-util = { version = "0.3", default-features = false }
-ssi = { path = "../../ssi", default-features = false }
+ssi = { path = "../../ssi", default-features = false, features = ["ed25519-dalek", "sha2", "rsa", "rand"] }
 percent-encoding = "2.1"
 
 [dev-dependencies]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -5,14 +5,14 @@ authors = ["Charles E. Lehner <charles.lehner@spruceid.com>"]
 edition = "2018"
 
 [features]
-default = ["ring"]
+default = []
 ring = ["ssi/ring"]
 wasm = []
 http-did = ["ssi/http-did"]
 
 [dependencies]
 #didkit_cbindings = { path = "cbindings/" }
-ssi = { path = "../../ssi", default-features = false }
+ssi = { path = "../../ssi", default-features = false, features = ["ed25519-dalek", "sha2", "rsa", "rand"] }
 did-key = { path = "../../ssi/did-key" }
 did-tezos = { path = "../../ssi/did-tezos" }
 did-web = { path = "../../ssi/did-web", optional = true }

--- a/lib/flutter/example/lib/main.dart
+++ b/lib/flutter/example/lib/main.dart
@@ -14,7 +14,7 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  String _platformVersion = 'Unknown';
+  String _didkitVersion = 'Unknown';
 
   @override
   void initState() {
@@ -24,12 +24,12 @@ class _MyAppState extends State<MyApp> {
 
   // Platform messages are asynchronous, so we initialize in an async method.
   Future<void> initPlatformState() async {
-    String platformVersion;
+    String didkitVersion;
     // Platform messages may fail, so we use a try/catch PlatformException.
     try {
-      platformVersion = await DIDKit.platformVersion;
+      didkitVersion = await DIDKit.getVersion();
     } on PlatformException {
-      platformVersion = 'Failed to get platform version.';
+      didkitVersion = 'Failed to get platform version.';
     }
 
     // If the widget was removed from the tree while the asynchronous platform
@@ -38,7 +38,7 @@ class _MyAppState extends State<MyApp> {
     if (!mounted) return;
 
     setState(() {
-      _platformVersion = platformVersion;
+      _didkitVersion = didkitVersion;
     });
   }
 
@@ -50,7 +50,7 @@ class _MyAppState extends State<MyApp> {
           title: const Text('Plugin example app'),
         ),
         body: Center(
-          child: Text('Running on: $_platformVersion\n'),
+          child: Text('Running DIDKit: $_didkitVersion\n'),
         ),
       ),
     );

--- a/lib/flutter/example/pubspec.lock
+++ b/lib/flutter/example/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety"
+    version: "2.5.0-nullsafety.3"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0-nullsafety.3"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.1.0-nullsafety.5"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0-nullsafety.3"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0-nullsafety.3"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.2"
+    version: "1.15.0-nullsafety.5"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -50,20 +50,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  didkit:
+    dependency: "direct main"
+    description:
+      path: ".."
+      relative: true
+    source: path
+    version: "0.1.0-nullsafety.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.2.0-nullsafety.3"
   ffi:
     dependency: transitive
     description:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.3.0-nullsafety.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,21 +87,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety"
+    version: "0.12.10-nullsafety.3"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.6"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.0-nullsafety.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -106,62 +113,55 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
-  didkit:
-    dependency: "direct main"
-    description:
-      path: ".."
-      relative: true
-    source: path
-    version: "0.0.1"
+    version: "1.8.0-nullsafety.4"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety"
+    version: "1.10.0-nullsafety.6"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0-nullsafety.3"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0-nullsafety.3"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0-nullsafety.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety"
+    version: "0.2.19-nullsafety.6"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.5"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0-nullsafety.5"
 sdks:
-  dart: ">=2.10.0-0.0.dev <2.10.0"
+  dart: ">=2.12.0-259.8.beta <3.0.0"

--- a/lib/flutter/lib/didkit.dart
+++ b/lib/flutter/lib/didkit.dart
@@ -21,6 +21,9 @@ final get_error_code = lib
 final generate_ed25519_key = lib
   .lookupFunction<Pointer<Utf8> Function(), Pointer<Utf8> Function()>('didkit_vc_generate_ed25519_key');
 
+final generate_ed25519_key_from_secret = lib
+  .lookupFunction<Pointer<Utf8> Function(Pointer<Utf8>), Pointer<Utf8> Function(Pointer<Utf8>)>('didkit_vc_generate_ed25519_key_from_secret');
+
 final key_to_did = lib
   .lookupFunction<Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>), Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>)>('didkit_key_to_did');
 
@@ -77,6 +80,14 @@ class DIDKit {
 
   static String generateEd25519Key() {
     final key = generate_ed25519_key();
+    if (key.address == nullptr.address) throw lastError();
+    final key_string = Utf8.fromUtf8(key);
+    free_string(key);
+    return key_string;
+  }
+
+  static String generateEd25519KeyFromSecret(String secret) {
+    final key = generate_ed25519_key_from_secret(Utf8.toUtf8(secret));
     if (key.address == nullptr.address) throw lastError();
     final key_string = Utf8.fromUtf8(key);
     free_string(key);

--- a/lib/flutter/pubspec.yaml
+++ b/lib/flutter/pubspec.yaml
@@ -1,11 +1,11 @@
 name: didkit
 description: A new flutter plugin project.
-version: 0.0.1
+version: 0.1.0-nullsafety.0
 author: Charles E. Lehner <charles.lehner@spruceid.com>
 homepage: https://github.com/spruceid/didkit/tree/main/lib/flutter
 
 environment:
-  sdk: ">=2.11.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
   ffi: ^0.3.0-nullsafety.1

--- a/lib/flutter/test/didkit_test.dart
+++ b/lib/flutter/test/didkit_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:didkit/didkit.dart';
 import 'dart:convert';
@@ -86,15 +85,15 @@ void main() {
 
   test('resolveDID', () async {
     final key = DIDKit.generateEd25519Key();
-    final did = DIDKit.keyToDID("key", key);
-    final resolutionResult = jsonDecode(DIDKit.resolveDID(did, "{}"));
+    final did = DIDKit.keyToDID('key', key);
+    final resolutionResult = jsonDecode(DIDKit.resolveDID(did, '{}'));
     expect(resolutionResult['didDocument'], isNotEmpty);
   });
 
   test('dereferenceDIDURL', () async {
     final key = DIDKit.generateEd25519Key();
-    final verificationMethod = DIDKit.keyToVerificationMethod("key", key);
-    final derefResult = jsonDecode(DIDKit.dereferenceDIDURL(verificationMethod, "{}"));
+    final verificationMethod = DIDKit.keyToVerificationMethod('key', key);
+    final derefResult = jsonDecode(DIDKit.dereferenceDIDURL(verificationMethod, '{}'));
     expect(derefResult, isList);
   });
 }

--- a/lib/node/native/Cargo.toml
+++ b/lib/node/native/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 neon-build = "0.6.0"
 
 [dependencies]
-ssi = { path = "../../../../ssi" }
+ssi = { path = "../../../../ssi", default-features = false, features = ["ed25519-dalek", "sha2", "rsa", "rand"] }
 didkit = { path = "../../", default-features = false }
 neon = "0.6.0"
 neon-serde = { git = "https://github.com/theosirian/neon-serde" }

--- a/lib/src/c.rs
+++ b/lib/src/c.rs
@@ -54,6 +54,22 @@ pub extern "C" fn didkit_vc_generate_ed25519_key() -> *const c_char {
     ccchar_or_error(generate_ed25519_key())
 }
 
+// Generate Ed25519 key from a secret
+fn generate_ed25519_key_from_secret(secret_ptr: *const c_char) -> Result<*const c_char, Error> {
+    let secret = unsafe { CStr::from_ptr(secret_ptr) }.to_str()?;
+    let jwk = JWK::generate_ed25519_from_secret(secret)?;
+    Ok(CString::new(serde_json::to_string(&jwk)?)?.into_raw())
+}
+/// Generate a new Ed25519 keypair in JWK format from a secret. On success, returns a pointer to a
+/// newly-allocated string containing the JWK. The string must be freed with [`didkit_free_string`]. On
+/// failure, returns `NULL`; the error message can be retrieved with [`didkit_error_message`].
+#[no_mangle]
+pub extern "C" fn didkit_vc_generate_ed25519_key_from_secret(
+    secret: *const c_char,
+) -> *const c_char {
+    ccchar_or_error(generate_ed25519_key_from_secret(secret))
+}
+
 // Convert JWK to did:key DID
 fn key_to_did(
     method_name_ptr: *const c_char,

--- a/lib/src/jni.rs
+++ b/lib/src/jni.rs
@@ -52,6 +52,25 @@ pub extern "system" fn Java_com_spruceid_DIDKit_generateEd25519Key(
     jstring_or_error(&env, generate_ed25519_key(&env))
 }
 
+fn generate_ed25519_key_from_secret(
+    env: &JNIEnv,
+    secret_jstring: JString,
+) -> Result<jstring, Error> {
+    let secret: String = env.get_string(secret_jstring).unwrap().into();
+    let jwk = JWK::generate_ed25519_from_secret(&secret)?;
+    let jwk_json = serde_json::to_string(&jwk)?;
+    Ok(env.new_string(jwk_json).unwrap().into_inner())
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_spruceid_DIDKit_generateEd25519KeyFromSecret(
+    env: JNIEnv,
+    _class: JClass,
+    secret: JString,
+) -> jstring {
+    jstring_or_error(&env, generate_ed25519_key_from_secret(&env, secret))
+}
+
 fn key_to_did(
     env: &JNIEnv,
     method_name_jstring: JString,


### PR DESCRIPTION
Add `GenerateEd25519KeyFromSecret` to support Key Recovery functionality on Credible. Currently only implemented in the alternative set of crypto libraries (`ed25519-dalek`,`sha2`,`rsa`,`rand`). Trying to use it with `ring` will just generate a new key.

Depends on https://github.com/spruceid/ssi/pull/91