### PR TITLE
Make example.sh DID method configurable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         repository: spruceid/ssi
         path: ssi
-        ref: a46a8eaab220684e4b73c5aa025de7b6270340d9
+        ref: 9e1c6309b333cbb3899d9a2e30d58b352a1c33ef
 
     - name: Cache Cargo registry and build artifacts
       uses: actions/cache@v2
@@ -59,6 +59,16 @@ jobs:
       run: cli/tests/example.sh
 
     - name: Test HTTP server
+      run: http/tests/example.sh
+
+    - name: Test CLI (did:tz)
+      env:
+        DID_METHOD: tz
+      run: cli/tests/example.sh
+
+    - name: Test HTTP server (did:tz)
+      env:
+        DID_METHOD: tz
       run: http/tests/example.sh
 
     - name: Checkout vc-http-api

--- a/cli/tests/example.sh
+++ b/cli/tests/example.sh
@@ -5,6 +5,10 @@
 # Exit if any command in the script fails.
 set -e
 
+# Allow issuing using a DID method other than did:key
+did_method=${DID_METHOD:-key}
+# More info about did:key: https://w3c-ccg.github.io/did-method-key/
+
 # Pretty-print JSON using jq or json_pp if available.
 print_json() {
 	file=${1?file}
@@ -35,14 +39,13 @@ else
 fi
 echo
 
-# Get the keypair's did:key DID.
-# More info about did:key: https://w3c-ccg.github.io/did-method-key/
-did=$(didkit key-to-did key -k key.jwk)
+# Get the keypair's DID.
+did=$(didkit key-to-did "$did_method" -k key.jwk)
 printf 'DID: %s\n\n' "$did"
 
 # Get verificationMethod for keypair.
 # This is used to identify the key in linked data proofs.
-verification_method=$(didkit key-to-verification-method key -k key.jwk)
+verification_method=$(didkit key-to-verification-method "$did_method" -k key.jwk)
 printf 'verificationMethod: %s\n\n' "$verification_method"
 
 # Prepare credential for issuing.

--- a/http/tests/example.sh
+++ b/http/tests/example.sh
@@ -6,6 +6,10 @@
 # Exit if any command in the script fails.
 set -e
 
+# Allow issuing using a DID method other than did:key
+did_method=${DID_METHOD:-key}
+# More info about did:key: https://w3c-ccg.github.io/did-method-key/
+
 # Pretty-print JSON using jq or json_pp if available.
 print_json() {
 	file=${1?file}
@@ -36,14 +40,13 @@ else
 fi
 echo
 
-# Get the keypair's did:key DID.
-# More info about did:key: https://w3c-ccg.github.io/did-method-key/
-did=$(didkit key-to-did key -k key.jwk)
+# Get the keypair's DID.
+did=$(didkit key-to-did "$did_method" -k key.jwk)
 printf 'DID: %s\n' "$did"
 
 # Get verificationMethod for keypair.
 # This is used to identify the key in linked data proofs.
-verification_method=$(didkit key-to-verification-method key -k key.jwk)
+verification_method=$(didkit key-to-verification-method "$did_method" -k key.jwk)
 printf 'verificationMethod: %s\n' "$verification_method"
 
 # Start the HTTP server


### PR DESCRIPTION
This enables using the CLI and HTTP `example.sh` script with other DID methods besides `did:key` that can be derived from a JWK. Using these with `did:tz` is added to the CI.

Depends on https://github.com/spruceid/ssi/pull/92