### PR TITLE
Enable external signing for WASM and did:ethr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         repository: spruceid/ssi
         path: ssi
-        ref: 000be6ba9ade255df529a6555016f9b4ae516eca
+        ref: a160cad6217864b7164012aa12e4bf9924c42073
 
     - name: Cache Cargo registry and build artifacts
       uses: actions/cache@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         repository: spruceid/ssi
         path: ssi
-        ref: cde184bef211cd2d8abda56573d9ffcbb7f19655
+        ref: 000be6ba9ade255df529a6555016f9b4ae516eca
 
     - name: Cache Cargo registry and build artifacts
       uses: actions/cache@v2

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -9,6 +9,7 @@ default = ["ring"]
 ring = ["ssi/ring"]
 wasm = []
 http-did = ["ssi/http-did"]
+secp256k1 = ["ssi/libsecp256k1", "did-tezos/secp256k1", "did-key/secp256k1"]
 
 [dependencies]
 #didkit_cbindings = { path = "cbindings/" }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,6 +16,7 @@ secp256k1 = ["ssi/libsecp256k1", "did-tezos/secp256k1", "did-key/secp256k1"]
 ssi = { path = "../../ssi", default-features = false }
 did-key = { path = "../../ssi/did-key" }
 did-tezos = { path = "../../ssi/did-tezos" }
+did-ethr = { path = "../../ssi/did-ethr" }
 did-web = { path = "../../ssi/did-web", optional = true }
 serde_json = "1.0"
 jni = "0.17"

--- a/lib/src/did_methods.rs
+++ b/lib/src/did_methods.rs
@@ -1,3 +1,4 @@
+use did_ethr::DIDEthr;
 use did_key::DIDKey;
 use did_tezos::DIDTz;
 #[cfg(feature = "did-web")]
@@ -9,6 +10,7 @@ lazy_static! {
         let mut methods = DIDMethods::default();
         methods.insert(&DIDKey);
         methods.insert(&DIDTz);
+        methods.insert(&DIDEthr);
         #[cfg(feature = "did-web")]
         methods.insert(&DIDWeb);
         methods

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -22,6 +22,7 @@ pub use ssi::did_resolve::{
 };
 pub use ssi::jwk::JWK;
 pub use ssi::ldp::resolve_key;
+pub use ssi::ldp::ProofPreparation;
 pub use ssi::vc::get_verification_method;
 pub use ssi::vc::Credential as VerifiableCredential;
 pub use ssi::vc::LinkedDataProofOptions;

--- a/lib/wasm/Cargo.toml
+++ b/lib/wasm/Cargo.toml
@@ -21,7 +21,15 @@ features = ["wasm"]
 [dependencies.ssi]
 path = "../../../ssi"
 default-features = false
-features = ["ed25519-dalek", "sha2", "rsa", "rand"]
+features = ["ed25519-dalek", "sha2", "rsa", "rand", "libsecp256k1"]
+
+[dependencies.did-key]
+path = "../../../ssi/did-key"
+features = ["secp256k1"]
+
+[dependencies.did-tezos]
+path = "../../../ssi/did-tezos"
+features = ["secp256k1"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.2"

--- a/lib/wasm/src/lib.rs
+++ b/lib/wasm/src/lib.rs
@@ -9,6 +9,7 @@ use didkit::error::Error;
 use didkit::error::{didkit_error_code, didkit_error_message};
 use didkit::get_verification_method;
 use didkit::LinkedDataProofOptions;
+use didkit::ProofPreparation;
 use didkit::Source;
 use didkit::VerifiableCredential;
 use didkit::VerifiablePresentation;
@@ -131,6 +132,62 @@ pub fn issueCredential(
     key: String,
 ) -> Promise {
     map_async_jsvalue(issue_credential(credential, linked_data_proof_options, key))
+}
+
+async fn prepare_issue_credential(
+    credential: String,
+    linked_data_proof_options: String,
+    public_key: String,
+) -> Result<String, Error> {
+    let public_key: JWK = serde_json::from_str(&public_key)?;
+    let credential = VerifiableCredential::from_json_unsigned(&credential)?;
+    let options: LinkedDataProofOptions = serde_json::from_str(&linked_data_proof_options)?;
+    let preparation = credential.prepare_proof(&public_key, &options).await?;
+    let preparation_json = serde_json::to_string(&preparation)?;
+    Ok(preparation_json)
+}
+
+#[wasm_bindgen]
+#[allow(non_snake_case)]
+#[cfg(feature = "issue")]
+pub fn prepareIssueCredential(
+    credential: String,
+    linked_data_proof_options: String,
+    public_key: String,
+) -> Promise {
+    map_async_jsvalue(prepare_issue_credential(
+        credential,
+        linked_data_proof_options,
+        public_key,
+    ))
+}
+
+async fn complete_issue_credential(
+    credential: String,
+    preparation: String,
+    signature: String,
+) -> Result<String, Error> {
+    let mut credential = VerifiableCredential::from_json_unsigned(&credential)?;
+    let preparation: ProofPreparation = serde_json::from_str(&preparation)?;
+    let proof = preparation.complete(&signature).await?;
+    credential.add_proof(proof);
+    let vc_json = serde_json::to_string(&credential)?;
+    Ok(vc_json)
+}
+
+#[wasm_bindgen]
+#[allow(non_snake_case)]
+#[cfg(feature = "issue")]
+pub fn completeIssueCredential(
+    credential: String,
+    preparation: String,
+    signature: String,
+) -> Promise {
+    map_async_jsvalue(complete_issue_credential(
+        credential,
+        preparation,
+        signature,
+    ))
 }
 
 #[cfg(any(


### PR DESCRIPTION
Depends on: https://github.com/spruceid/ssi/pull/99

This adds functions to DIDKit's WASM API for credential issuance with external signing. This approach splits issuance into two parts, one is everything up to the cryptographic signing, and the other is everything after. There are two functions added, one to prepare issuing a credential, and another to complete issuing the credential. The `prepareIssueCredential` function returns a [`ProofPreparation`](https://github.com/spruceid/ssi/blob/29bbbe1d7a5bd1825d71c05dc083bef7fbd075f1/src/ldp.rs#L76-L80) object which includes the data to sign. The `completeIssueCredential` function takes this proof preparation and the signed data along with same credential and returns the credential issued with the completed proof.

These functions are only currently added to the WASM API. If it is a good approach, it could be added to the other FFIs, CLI and HTTP interface.

Edit: an integration example is https://github.com/spruceid/degen-issuer/pull/7