### PR TITLE
Implement DIDAuth

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         repository: spruceid/ssi
         path: ssi
-        ref: a160cad6217864b7164012aa12e4bf9924c42073
+        ref: 6b0917fdfd08f824d8470d3ffc6310fd683a45b9
 
     - name: Cache Cargo registry and build artifacts
       uses: actions/cache@v2

--- a/cli/tests/example.sh
+++ b/cli/tests/example.sh
@@ -163,4 +163,36 @@ fi
 echo 'Dereferenced DID URL for verification method:'
 print_json vm.json
 
+# Authenticate with a DID
+if ! challenge=$(awk 'BEGIN { srand(); print rand() }')
+then
+	echo 'Unable to create challenge.'
+	exit 1
+fi
+if ! didkit did-auth \
+	-k key.jwk \
+	-h "$did" \
+	-p authentication \
+	-C "$challenge" \
+	-v "$verification_method" \
+	> auth.jsonld
+then
+	echo 'Unable to create DIDAuth response'
+	exit 1
+fi
+
+# Verify DID auth
+if ! didkit vc-verify-presentation \
+	-p authentication \
+	-C "$challenge" \
+	< auth.jsonld \
+	> auth-verify-result.json
+then
+	echo 'Unable to verify DIDAuth presentation:'
+	print_json auth-verify-result.json
+	exit 1
+fi
+echo 'Verified DIDAuth verifiable presentation:'
+print_json auth-verify-result.json
+
 echo Done

--- a/lib/flutter/lib/didkit.dart
+++ b/lib/flutter/lib/didkit.dart
@@ -45,6 +45,9 @@ final resolve_did = lib
 final dereference_did_url = lib
   .lookupFunction<Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>), Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>)>('didkit_did_url_dereference');
 
+final did_auth = lib
+  .lookupFunction<Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>), Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)>('didkit_did_auth');
+
 final free_string = lib
   .lookupFunction<Void Function(Pointer<Utf8>), void Function(Pointer<Utf8>)>('didkit_free_string');
 
@@ -154,6 +157,14 @@ class DIDKit {
     final result_string = Utf8.fromUtf8(result);
     free_string(result);
     return result_string;
+  }
+
+  static String DIDAuth(String did, String options, String key) {
+    final vp = did_auth(Utf8.toUtf8(did), Utf8.toUtf8(options), Utf8.toUtf8(key));
+    if (vp.address == nullptr.address) throw lastError();
+    final vp_string = Utf8.fromUtf8(vp);
+    free_string(vp);
+    return vp_string;
   }
 
 }

--- a/lib/flutter/pubspec.lock
+++ b/lib/flutter/pubspec.lock
@@ -43,6 +43,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0-nullsafety.5"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0-nullsafety.0"
   fake_async:
     dependency: transitive
     description:
@@ -149,6 +156,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0-nullsafety.5"
+  uuid:
+    dependency: "direct dev"
+    description:
+      name: uuid
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0-nullsafety.1"
   vector_math:
     dependency: transitive
     description:

--- a/lib/flutter/pubspec.yaml
+++ b/lib/flutter/pubspec.yaml
@@ -14,6 +14,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   pedantic: ^1.10.0
+  uuid: ^3.0.0-nullsafety.0
 
 flutter:
   plugin:

--- a/lib/java/main/com/spruceid/DIDKit.java
+++ b/lib/java/main/com/spruceid/DIDKit.java
@@ -10,6 +10,7 @@ public class DIDKit {
     public static native String issueCredential(String credential, String linkedDataProofOptions, String key) throws DIDKitException;
     public static native String verifyCredential(String verifiableCredential, String linkedDataProofOptions);
     public static native String issuePresentation(String presentation, String linkedDataProofOptions, String key) throws DIDKitException;
+    public static native String DIDAuth(String holder, String linkedDataProofOptions, String key) throws DIDKitException;
     public static native String verifyPresentation(String verifiablePresentation, String linkedDataProofOptions);
     public static native String resolveDID(String did, String inputMetadata);
     public static native String dereferenceDIDURL(String didUrl, String inputMetadata);

--- a/lib/java/test/com/spruceid/DIDKitTest.java
+++ b/lib/java/test/com/spruceid/DIDKitTest.java
@@ -76,5 +76,21 @@ class DIDKitTest {
         // Dereference DID URL
         String dereferencingResult = DIDKit.dereferenceDIDURL(verificationMethod, "{}");
         assert vpResult.startsWith("[{");
+
+        // Create a DIDAuth VP
+        vpOptions = "{"
+            + "  \"proofPurpose\": \"authentication\","
+            + "  \"domain\": \"example.org\","
+            + "  \"verificationMethod\": \"" + verificationMethod + "\""
+            + "}";
+        vp = DIDKit.DIDAuth(did, vpOptions, jwk);
+
+        // Verify Presentation
+        vpVerifyOptions = "{"
+            + "  \"domain\": \"example.org\","
+            + "  \"proofPurpose\": \"authentication\""
+            + "}";
+        vpResult = DIDKit.verifyPresentation(vp, vpVerifyOptions);
+        assert vpResult.contains("\"errors\":[]");
     }
 }

--- a/lib/node/native/src/didkit.rs
+++ b/lib/node/native/src/didkit.rs
@@ -104,6 +104,22 @@ pub fn issue_presentation(mut cx: FunctionContext) -> JsResult<JsValue> {
     Ok(vp)
 }
 
+pub fn did_auth(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let holder = arg!(cx, 0, String);
+    let options = arg!(cx, 1, LinkedDataProofOptions);
+    let key = arg!(cx, 2, JWK);
+
+    let mut presentation = VerifiablePresentation::default();
+    presentation.holder = Some(ssi::vc::URI::String(holder));
+
+    let rt = throws!(cx, runtime::get())?;
+    let proof = throws!(cx, rt.block_on(presentation.generate_proof(&key, &options)))?;
+    presentation.add_proof(proof);
+
+    let vp = throws!(cx, neon_serde::to_value(&mut cx, &presentation))?;
+    Ok(vp)
+}
+
 pub fn verify_presentation(mut cx: FunctionContext) -> JsResult<JsValue> {
     let vp = arg!(cx, 0, VerifiablePresentation);
     let options = arg!(cx, 1, LinkedDataProofOptions);

--- a/lib/node/native/src/lib.rs
+++ b/lib/node/native/src/lib.rs
@@ -19,6 +19,7 @@ register_module!(mut m, {
 
     m.export_function("issuePresentation", didkit::issue_presentation)?;
     m.export_function("verifyPresentation", didkit::verify_presentation)?;
+    m.export_function("DIDAuth", didkit::did_auth)?;
 
     Ok(())
 });

--- a/lib/node/package-lock.json
+++ b/lib/node/package-lock.json
@@ -5771,11 +5771,10 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
-      "dev": true,
-      "optional": true
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.2.0",

--- a/lib/node/package.json
+++ b/lib/node/package.json
@@ -15,7 +15,8 @@
     "eslint-plugin-prettier": "^3.3.1",
     "jest": "^26.6.3",
     "node-pre-gyp-github": "^1.4.3",
-    "prettier": "2.2.1"
+    "prettier": "2.2.1",
+    "uuid": "^8.3.2"
   },
   "scripts": {
     "build": "neon build",

--- a/lib/node/test/index.spec.js
+++ b/lib/node/test/index.spec.js
@@ -1,4 +1,5 @@
 const DIDKit = require("..");
+const uuid = require("uuid").v4;
 
 const key = {
   kty: "OKP",
@@ -118,6 +119,41 @@ describe("presentation", () => {
 
     const verifyResult = DIDKit.verifyPresentation(presentation, {
       proofPurpose: "authentication",
+    });
+
+    expect(verifyResult["errors"].length).toBe(0);
+  });
+});
+
+describe("DIDAuth", () => {
+  var did, verificationMethod;
+
+  beforeAll(() => {
+    did = DIDKit.keyToDID("key", key);
+    verificationMethod = DIDKit.keyToVerificationMethod("key", key);
+  });
+
+  it("should fail if parameters are empty", () => {
+    expect(() => {
+      DIDKit.DIDAuth("", {}, {});
+    }).toThrow();
+  });
+
+  it("should issue and verify DIDAuth verifiable presentation", () => {
+    const challenge = uuid();
+    const presentation = DIDKit.DIDAuth(
+      did,
+      {
+        proofPurpose: "authentication",
+        verificationMethod,
+        challenge
+      },
+      key
+    );
+
+    const verifyResult = DIDKit.verifyPresentation(presentation, {
+      proofPurpose: "authentication",
+      challenge
     });
 
     expect(verifyResult["errors"].length).toBe(0);

--- a/lib/wasm/loader/test/index.test.js
+++ b/lib/wasm/loader/test/index.test.js
@@ -17,6 +17,7 @@ DIDKitLoader.loadDIDKit("/didkit_wasm_bg.wasm").then(
     verifyCredential,
     issuePresentation,
     verifyPresentation,
+    DIDAuth,
   }) => {
     const emptyObj = JSON.stringify({});
 
@@ -160,6 +161,33 @@ DIDKitLoader.loadDIDKit("/didkit_wasm_bg.wasm").then(
         presentation,
         JSON.stringify({
           proofPurpose: "authentication",
+        })
+      );
+
+      const verify = JSON.parse(verifyStr);
+
+      if (verify.errors.length > 0) throw verify.errors;
+    });
+
+    test("should issue and verify DIDAuth presentation", async () => {
+      const challenge = Math.random().toString(16).substr(2);
+      const verifiablePresentation = JSON.parse(
+        await DIDAuth(
+          did,
+          JSON.stringify({
+            proofPurpose: "authentication",
+            challenge,
+            verificationMethod,
+          }),
+          keyStr
+        )
+      );
+
+      const verifyStr = await verifyPresentation(
+        JSON.stringify(verifiablePresentation),
+        JSON.stringify({
+          proofPurpose: "authentication",
+          challenge,
         })
       );
 


### PR DESCRIPTION
Depends on: https://github.com/spruceid/ssi/pull/105

A DIDAuth command/function is added to:
- CLI
- C
- JNI
- Flutter/Dart
- Node
- WASM
- tests
- CLI readme

I didn't add it to the HTTP interface because this is not specified in the VC HTTP API or DID Resolution HTTP(S) Binding.

The DIDAuth function takes a holder URI (e.g. a DID), linked data proof options (same as for issuing a credential or presentation), and a JWK, and generates a [Verifiable Presentation](https://w3c.github.io/vc-data-model/#presentations-0) (which does not contain a `verifiableCredential`).

Reference: https://w3c-ccg.github.io/vp-request-spec/#did-authentication-request