### PR TITLE
Fix Webpack config file for didkit-loader (wasm)

### DIFF
--- a/lib/wasm/loader/webpack.config.js
+++ b/lib/wasm/loader/webpack.config.js
@@ -8,14 +8,6 @@ module.exports = {
   optimization: {
     minimize: true,
   },
-  module: {
-    rules: [
-      {
-        test: /\.wasm$/,
-        use: [{ loader: "wasm-loader" }],
-      },
-    ],
-  },
   output: {
     path: path.resolve(__dirname),
     filename: "[name].min.js",


### PR DESCRIPTION
Attempt to fix #87
The webpack configuration file didn't need the `wasm-loader` section.
Probably forgot to remove that when I made the PR for WASM.

