### PR TITLE
Update didkit-node README code sample

### DIFF
--- a/lib/node/README.md
+++ b/lib/node/README.md
@@ -22,8 +22,8 @@ const key = DIDKit.generateEd25519Key();
 
 // There are two helpful functions to obtain a DID and the `did:key`
 // `verificationMethod` from the key.
-const did = DIDKit.keyToDID(key);
-const verificationMethod = DIDKit.keyToVerificationMethod(key);
+const did = DIDKit.keyToDID('key', key);
+const verificationMethod = DIDKit.keyToVerificationMethod('key', key);
 ```
 
 ### Issuing a Credential


### PR DESCRIPTION
Small update, that can hopefully help someone perusing the node side of didkit. 💪 🎉 

Updates the node readme code sample to use proper arguments for `key-to-did` & `key-to-verification-method` for `keyToDID` and `keyToVerificationMethod` respectively. 

These functions require passing in the did method, in this case, "key". Other currently supported did method is "web" according to [CLI docs](https://github.com/spruceid/didkit/blob/main/cli/README.md#didkit-key-to-did-method_name). 