### PR TITLE
Fix Wallet Store Verification

### DIFF
--- a/examples/svelte-chapi-wallet/src/ui/wallet/WalletStore.svelte
+++ b/examples/svelte-chapi-wallet/src/ui/wallet/WalletStore.svelte
@@ -53,10 +53,8 @@
 
     accept = async () => {
       const { verifyCredential } = DIDKit;
-      const verificationMethod = `${data.issuer}#${data.issuer.substring(8)}`;
       const options = JSON.stringify({
-        verificationMethod,
-        proofPurpose: "assertionMethod",
+        /*proofPurpose: "assertionMethod",*/
       });
       const verifyStr = await verifyCredential(JSON.stringify(data), options);
       const verify = JSON.parse(verifyStr);


### PR DESCRIPTION
Fix store verification on Svelte CHAPI Wallet Example by removing `verificationMethod` and `proofPurpose` on the options.

Signed-off-by: Tiago Nascimento <tiago.nascimento@spruceid.com>