### PR TITLE
Use vc-http-api controller pattern

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -42,7 +42,7 @@ Given a Ed25519 [JWK][] and a supported DID method name, output the correspondin
 
 Issue a verifiable credential. Reads credential on stdin, constructs a [linked data proof][ld-proofs] to add to the credential, and outputs the resulting verifiable credential.
 
-Corresponds to [/issue/credentials](https://w3c-ccg.github.io/vc-http-api/#/Issuer/issueCredential) in [vc-http-api][].
+Corresponds to [/credentials/issue](https://w3c-ccg.github.io/vc-http-api/#operation/issueCredential) in [vc-http-api][].
 
 The proof type is set automatically based on the key file provided. JWK parameters besides the cryptographic components, such as [kid][] (Key ID), are ignored currently. For an RSA key, the [alg][] (Algorithm) parameter is ignored and `RS256` is used for it, for [RsaSignature2018][].
 
@@ -71,7 +71,7 @@ The following options correspond to linked data [proof options][] as specified i
 
 Verify a verifiable credential. Reads verifiable credential on standard input, and outputs verification result. Returns exit status zero if credential successfully verified, or non-zero if errors were encountered.
 
-Corresponds to [/verify/credentials](https://w3c-ccg.github.io/vc-http-api/#/Verifier/verifyCredential) in [vc-http-api][].
+Corresponds to [/credentials/verify](https://w3c-ccg.github.io/vc-http-api/#operation/verifyCredential) in [vc-http-api][].
 
 #### Options
 
@@ -113,7 +113,7 @@ Verification result properties:
 
 Issue a verifiable presentation. Reads presentation on stdin, generates proof to add to it, and outputs the resulting verifiable presentation.
 
-Corresponds to [/prove/presentations](https://w3c-ccg.github.io/vc-http-api/#/Holder/provePresentation) in [vc-http-api][].
+Corresponds to [/credentials/prove](https://w3c-ccg.github.io/vc-http-api/#operation/provePresentation) in [vc-http-api][].
 
 Options are the same as for [didkit vc-issue-credential](#didkit-vc-issue-credential).
 
@@ -121,7 +121,7 @@ Options are the same as for [didkit vc-issue-credential](#didkit-vc-issue-creden
 
 Verify a verifiable presentation. Reads verifiable presentation on stdin, and outputs verification result. Returns exit status zero if presentation successfully verified, or non-zero if errors were encountered.
 
-Corresponds to [/verify/presentations](https://w3c-ccg.github.io/vc-http-api/#/Verifier/verifyPresentation) in [vc-http-api][].
+Corresponds to [/presentations/verify](https://w3c-ccg.github.io/vc-http-api/#operation/verifyPresentation) in [vc-http-api][].
 
 Options and output format are the same as for [didkit vc-verify-credential](#didkit-vc-verify-credential).
 

--- a/http/README.md
+++ b/http/README.md
@@ -46,19 +46,19 @@ library. Struct `didkit_http::DIDKitHTTPMakeSvc` implements a Tower
 
 The following routes implement [W3C CCG's VC HTTP API (vc-http-api)][vc-http-api] [v0.0.1][vc-http-api-0.0.1]. POST bodies should be `application/json`. Output will be `application/json` on success; on error it will be either `application/json` or plain text. For more details, see `vc-http-api`.
 
-#### POST `/issue/credentials`
+#### POST `/credentials/issue`
 
 Issue a verifiable credential. The server uses its configured key and the given linked data proof options to generate a proof and append it to the given credential. On success, the resulting verifiable credential is returned, with HTTP status 201.
 
-#### POST `/verify/credentials`
+#### POST `/credentials/verify`
 
 Verify a verifiable credential. The server verifies the given credential with the given linked data proof options. To successfully verify, the credential must contain at least one proof that verifies successfully. Verification results include a list of checks performed, warnings that should be flagged to the user, and errors encountered. On success, the errors list will be empty, and the HTTP status code will be 200.
 
-#### POST `/prove/presentations`
+#### POST `/credentials/prove`
 
 Create a verifiable presentation. Given a presentation and linked data proof options, the server uses its key to generate a proof and append it to the presentation. On success, returns the verifiable presentation and HTTP status 201.
 
-#### POST `/verify/presentations`
+#### POST `/presentations/verify`
 
 Verify a verifiable presentation using the given proof options. Returns a verification result. HTTP status 200 indicates successful verification.
 

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -553,13 +553,20 @@ impl Service<Request<Body>> for DIDKitHTTPSvc {
     fn call(&mut self, req: Request<Body>) -> Self::Future {
         let path = req.uri().path();
         match path {
+            // vc-http-api 0.0.1
             "/issue/credentials" => return self.issue_credentials(req),
             "/verify/credentials" => return self.verify_credentials(req),
             "/prove/presentations" => return self.prove_presentations(req),
             "/verify/presentations" => return self.verify_presentations(req),
+            // vc-http-api 0.0.2-unstable
+            "/credentials/issue" => return self.issue_credentials(req),
+            "/credentials/verify" => return self.verify_credentials(req),
+            "/credentials/prove" => return self.prove_presentations(req),
+            "/presentations/verify" => return self.verify_presentations(req),
             _ => {}
         };
         if path.starts_with("/identifiers/") {
+            // DID Resolution HTTP(S) binding
             return self.resolve_dereference(req);
         }
         self.not_found()

--- a/http/tests/example.sh
+++ b/http/tests/example.sh
@@ -79,7 +79,7 @@ EOF
 # standard input. DIDKit creates a linked data proof to add to the credential,
 # and outputs the resulting newly-issued verifiable credential on standard
 # output, which we save to a file.
-if ! curl -fsS $didkit_url/issue/credentials \
+if ! curl -fsS $didkit_url/credentials/issue \
 	-H 'Content-Type: application/json' \
 	-o credential-signed.jsonld \
 	-d @- <<EOF
@@ -105,7 +105,7 @@ echo
 # verification using the given verification method and proof purpose. DIDKit
 # outputs the verification result as JSON. If verification is successful, the
 # command completes successfully (returns exit code 0).
-if ! curl -fsS $didkit_url/verify/credentials \
+if ! curl -fsS $didkit_url/credentials/verify \
 	-H 'Content-Type: application/json' \
 	-o credential-verify-result.json \
 	-d @- <<EOF
@@ -143,7 +143,7 @@ EOF
 # verifiable presentation. DIDKit signs the presentation with a linked data
 # proof, using the given keypair, verification method and proof type. We save
 # the resulting newly created verifiable presentation to a file.
-if ! curl -fsS $didkit_url/prove/presentations \
+if ! curl -fsS $didkit_url/credentials/prove \
 	-H 'Content-Type: application/json' \
 	-o presentation-signed.jsonld \
 	-d @- <<EOF
@@ -166,7 +166,7 @@ echo
 # Verify verifiable presentation.
 # Pass the verifiable presentation back to didkit for verification.
 # Examine the verification result JSON.
-if ! curl -fsS $didkit_url/verify/presentations \
+if ! curl -fsS $didkit_url/presentations/verify \
 	-H 'Content-Type: application/json' \
 	-o presentation-verify-result.json \
 	-d @- <<EOF

--- a/http/tests/main.rs
+++ b/http/tests/main.rs
@@ -84,7 +84,7 @@ async fn credential_presentation_issue_verify() {
     let client = Client::builder().build_http::<Body>();
 
     // Issue credential
-    let uri = Uri::from_str(&(base.to_string() + "/issue/credentials")).unwrap();
+    let uri = Uri::from_str(&(base.to_string() + "/credentials/issue")).unwrap();
     let body = Body::from(ISSUE_CRED_REQ);
     let req = Request::builder()
         .method("POST")
@@ -101,7 +101,7 @@ async fn credential_presentation_issue_verify() {
     assert!(!vc["proof"].is_null());
 
     // Verify credential
-    let uri = Uri::from_str(&(base.to_string() + "/verify/credentials")).unwrap();
+    let uri = Uri::from_str(&(base.to_string() + "/credentials/verify")).unwrap();
     let verify_cred_req = json!({
       "verifiableCredential": vc,
       "options": {
@@ -126,7 +126,7 @@ async fn credential_presentation_issue_verify() {
     eprintln!("verify credential response: {:?}", response);
 
     // Issue presentation
-    let uri = Uri::from_str(&(base.to_string() + "/prove/presentations")).unwrap();
+    let uri = Uri::from_str(&(base.to_string() + "/credentials/prove")).unwrap();
     let challenge = "a93fdb78-411a-4a34-ab1c-be9968b92f6b";
     let issue_pres_req = json!({
       "presentation": {
@@ -157,7 +157,7 @@ async fn credential_presentation_issue_verify() {
     eprintln!("issue presentation response: {:?}", vp);
 
     // Verify presentation
-    let uri = Uri::from_str(&(base.to_string() + "/verify/presentations")).unwrap();
+    let uri = Uri::from_str(&(base.to_string() + "/presentations/verify")).unwrap();
     let verify_pres_req = json!({
       "verifiablePresentation": vp,
       "options": {
@@ -212,7 +212,7 @@ async fn credential_issue_verify_other_key() {
     let (base, shutdown) = serve(Some(vec![key]));
     let client = Client::builder().build_http::<Body>();
     // Issue credential
-    let uri = Uri::from_str(&(base.to_string() + "/issue/credentials")).unwrap();
+    let uri = Uri::from_str(&(base.to_string() + "/credentials/issue")).unwrap();
     let mut cred_req: Value = serde_json::from_str(ISSUE_CRED_REQ).unwrap();
     cred_req["credential"]["issuer"] = json!(did);
     cred_req["options"]["verificationMethod"] = json!(verification_method);
@@ -234,7 +234,7 @@ async fn credential_issue_verify_other_key() {
     assert_eq!(vc["proof"]["verificationMethod"], verification_method);
 
     // Verify credential
-    let uri = Uri::from_str(&(base.to_string() + "/verify/credentials")).unwrap();
+    let uri = Uri::from_str(&(base.to_string() + "/credentials/verify")).unwrap();
     let verify_cred_req = json!({
       "verifiableCredential": vc,
       "options": {
@@ -265,7 +265,7 @@ async fn invalid_input() {
     let (base, shutdown) = serve(None);
     let client = Client::builder().build_http::<Body>();
 
-    let uri = Uri::from_str(&(base + "/issue/credentials")).unwrap();
+    let uri = Uri::from_str(&(base + "/credentials/issue")).unwrap();
     let req = Request::builder()
         .method("POST")
         .uri(uri)
@@ -282,7 +282,7 @@ async fn non_json_input() {
     let (base, shutdown) = serve(None);
     let client = Client::builder().build_http::<Body>();
 
-    let uri = Uri::from_str(&(base + "/issue/credentials")).unwrap();
+    let uri = Uri::from_str(&(base + "/credentials/issue")).unwrap();
     let body = Body::from(ISSUE_CRED_REQ);
     let req = Request::builder()
         .method("POST")
@@ -301,7 +301,7 @@ async fn non_json_accept() {
     let (base, shutdown) = serve(None);
     let client = Client::builder().build_http::<Body>();
 
-    let uri = Uri::from_str(&(base + "/issue/credentials")).unwrap();
+    let uri = Uri::from_str(&(base + "/credentials/issue")).unwrap();
     let body = Body::from(ISSUE_CRED_REQ);
     let req = Request::builder()
         .method("POST")


### PR DESCRIPTION
`vc-http-api` adopted controller pattern routes in v0.0.2-unstable: https://github.com/w3c-ccg/vc-http-api/pull/73

This PR updates `didkit-http` to use `vc-http-api v0.0.2-unstable`'s routes. The `vc-http-api v0.0.1` routes are left in, for backwards-compatibility, but documentation and examples are updated to use the `v0.0.2-unstable` routes.