### PR TITLE
Fix Variable Naming in Java Tests

### DIFF
--- a/lib/java/test/com/spruceid/DIDKitTest.java
+++ b/lib/java/test/com/spruceid/DIDKitTest.java
@@ -71,11 +71,11 @@ class DIDKitTest {
 
         // Resolve DID
         String resolutionResult = DIDKit.resolveDID(did, "{}");
-        assert vpResult.contains("\"didDocument\":{");
+        assert resolutionResult.contains("\"didDocument\":{");
 
         // Dereference DID URL
         String dereferencingResult = DIDKit.dereferenceDIDURL(verificationMethod, "{}");
-        assert vpResult.startsWith("[{");
+        assert dereferencingResult.startsWith("[{");
 
         // Create a DIDAuth VP
         vpOptions = "{"


### PR DESCRIPTION
While looking at the current test files for reference for a test file for Go, I noticed that the Java tests included two checks using the wrong variable.

Signed-off-by: Tiago Nascimento <tiago.nascimento@spruceid.com>