### PR TITLE
Remove files from CI to free up space

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,22 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - name: Free up disk space
+      working-directory: /
+      run: |
+        sudo rm -rf \
+          /home/linuxbrew \
+          /opt/az \
+          /opt/ghc \
+          /opt/hostedtoolcache/CodeQL \
+          /opt/hostedtoolcache/PyPy \
+          /usr/local/julia1.5.4 \
+          /usr/local/lib/node_modules/netlify-cli \
+          /usr/local/share/powershell \
+          /usr/share/dotnet \
+          /usr/share/miniconda \
+          /usr/share/swift
+
     - name: Checkout DIDKit repository
       uses: actions/checkout@v2
       with:
@@ -131,3 +147,6 @@ jobs:
 
     - name: Test Python Package
       run: make -C lib ../target/test/python.stamp
+
+    - name: Check final disk usage
+      run: df -h /


### PR DESCRIPTION
This PR changes CI to delete some of the built-in files, to free up space. As discovered in #108, we hit the limit of filesystem usage in CI. #110 freed up another 1 or 2 GB, but if we need more space, it seems we must delete some of the pre-existing files.

---

## Disk usage exploration

- [x] Find what is taking up a lot of disk space
  - [x] Run [ncdu](https://dev.yorhel.nl/ncdu) and export results.
  - [x] Analyze results
  - [x] Compare to disk usage post-build
- [x] Reduce space usage so that CI can run. Removed separate Android SDK/NDK installation: https://github.com/spruceid/didkit/pull/110

### Disk usage summary

Initial disk usage: 84G total, 67G used, 17G free ([step:2:7](https://github.com/spruceid/didkit/runs/2141200007?check_suite_focus=true#step:2:7))
After removing things: 36G used, 48G free ([step:4:7](https://github.com/spruceid/didkit/runs/2142403783#step:4:7)). Removal freed 31G.
Removal step takes 2m40s ([step:3:1](https://github.com/spruceid/didkit/runs/2142403783#step:3:1))
After build: 50G used, 34G free ([step:32:1](https://github.com/spruceid/didkit/runs/2142403783#step:32:1)). Build took 16G.

Full filesystem usage info obtained using `ncdu` in [Run 665122235](https://github.com/spruceid/didkit/actions/runs/665122235): artifact [ncdu.gz](https://github.com/spruceid/didkit/suites/2289858552/artifacts/47947446).
Examine using `zcat ncdu.gz | ncdu -f-`

Additional `ncdu` data from [Run 665519246](https://github.com/spruceid/didkit/actions/runs/665519246). Examine using e.g. `ncdu -f pre.ncdu`:
- [pre.ncdu](https://github.com/spruceid/didkit/suites/2291009403/artifacts/47982073) Filesystem after removing things and checking out repos, but before installing dependencies or building
- [post.ndcu](https://github.com/spruceid/didkit/suites/2291009403/artifacts/47982072) Filesystem after installing dependencies, building and running all tests.
- [wd.ncdu](https://github.com/spruceid/didkit/suites/2291009403/artifacts/47982074) `didkit` repo directory after build and test


#### Large directories

Size|Path
-:|-
 24.1 GiB|`/usr/share/dotnet`
 11.3 GiB|`/usr/local/lib/android/sdk`
  1.8 GiB|`/opt/ghc`
  1.3 GiB|`/opt/hostedtoolcache/Python`
  1.3 GiB|`/usr/share/swift`
  1.1 GiB|`/opt/hostedtoolcache/go`
  1.1 GiB|`/opt/hostedtoolcache/CodeQL`
  1.0 GiB|`/usr/local/graalvm/graalvm-ce-java11-21.0.0.2`
  1.0 GiB|`/var/lib/gems`
855.2 MiB|`/opt/az`
765.8 MiB|`/var/lib/snapd`
531.6 MiB|`/usr/share/rust`
562.1 MiB|`/home/linuxbrew`
465.9 MiB|`/opt/hostedtoolcache/PyPy`
374.3 MiB|`/usr/local/lib/node_modules/netlify-cli`
342.7 MiB|`/usr/share/miniconda`
368.2 MiB|`/usr/local/julia1.5.4`
289.9 MiB|`/usr/local/share/powershell`

### Apt clean
`apt clean` did not have a noticeable impact. [df before and after](https://github.com/spruceid/didkit/runs/2141055885#step:5:7)
<details>
<summary>Results of apt clean</summary>

![df -h output before and after apt clean](https://user-images.githubusercontent.com/95347/111653371-3fee3f80-87de-11eb-82bf-f026e8952c3c.png)
</details>
