### PR TITLE
Use default Android SDK/NDK in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,20 +98,6 @@ jobs:
         dart --disable-analytics
         flutter --suppress-analytics config --no-analytics
 
-    - name: Install Android SDK
-      uses: android-actions/setup-android@v2
-
-    - name: Cache Android NDK
-      id: ndk-cache
-      uses: actions/cache@v2
-      with:
-        path: ${{ env.ANDROID_SDK_ROOT }}/ndk-bundle
-        key: ${{ runner.os }}-ndk-bundle
-
-    - name: Install Android NDK
-      if: steps.ndk-cache.outputs.cache-hit != 'true'
-      run: $ANDROID_SDK_ROOT/tools/bin/sdkmanager ndk-bundle
-
     - name: Test C FFI
       run: make -C lib ../target/test/c.stamp
 


### PR DESCRIPTION
The CI Environment already includes Android SDK/NDK:
https://github.com/actions/virtual-environments/blob/ubuntu20/20210315.1/images/linux/Ubuntu2004-README.md#environment-variables-3

By using the Android SDK/NDK included in the environment rather than installing it separately, we save some space (#108) and time (#69).