### PR TITLE
Fix didkit paths in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,8 @@ jobs:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml', 'lib/Makefile', '**.rs') }}
+          didkit/target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml', 'didkit/lib/Makefile', '**.rs') }}
         restore-keys: |
           ${{ runner.os }}-cargo-
 


### PR DESCRIPTION
Fix #111 caching of Rust build artifacts in CI.

Full run, no cache: https://github.com/spruceid/didkit/runs/2142681378 45m 49s
Subsequent run, with caching: https://github.com/spruceid/didkit/runs/2143040544: failed for disk space reasons. Looks like we have to free up more space to make room for the larger cache file.

Cache size which previously was `~263 MB` (probably containing just the cargo registry data); is now up to `~2141 MB` ([step:4:23](https://github.com/spruceid/didkit/runs/2143040544#step:4:23)).