### PR TITLE
Use system's JDK in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,10 +96,8 @@ jobs:
     - name: Install wasm-pack
       run: make -C lib install-wasm-pack
 
-    - name: Install JDK
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
+    - name: Use system JDK
+      run: echo "$JAVA_HOME/bin" >> $GITHUB_PATH
 
     - name: Install Flutter
       uses: subosito/flutter-action@v1


### PR DESCRIPTION
Similar to #110, this reduces disk usage and time in CI by using the [environment's JDK](https://github.com/actions/virtual-environments/blob/ubuntu20/20210315.1/images/linux/Ubuntu2004-README.md#java). Note that the default is version 11, while we previously have been using version 8.