### PR TITLE
Generate DID with method pattern

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -23,20 +23,25 @@ Output help about `didkit` and its subcommands.
 
 Generate a Ed25519 keypair and output it in [JWK format](https://tools.ietf.org/html/rfc8037#appendix-A.1).
 
-### `didkit key-to-did <method_name>`
+### `didkit key-to-did <method_pattern>`
 
-Given a [JWK][] and a DID method name, output the corresponding DID.
+Given a [JWK][] and a supported DID method name or pattern, output the corresponding DID.
 
-Currently, this only supports [Ed25519](https://tools.ietf.org/html/rfc8037#appendix-A.2) keys, [did:key][] and [did:web][].
+### `didkit key-to-verification-method <method_pattern>`
 
-### `didkit key-to-verification-method <method_name>`
-
-Given a Ed25519 [JWK][] and a supported DID method name, output the corresponding [verificationMethod][].
+Given a [JWK][] and a supported DID method name or pattern, output the corresponding [verificationMethod][].
 
 #### Options
 
 - `-k, --key-path <file>` (required, conflicts with jwk) - Filename of JWK file
 - `-j, --jwk <jwk>` (required, conflicts with key-path) - JWK.
+
+#### Supported DID method names and patterns
+
+- `key` - [did:key][] ([Ed25519][], [P-256][] [Secp256k1][])
+- `tz` - [did:tz][] ([Ed25519][], [P-256][] [Secp256k1][])
+- `ethr` - [did:ethr][] ([Secp256k1][])
+- `sol` - `did:sol` ([Ed25519][])
 
 ### `didkit vc-issue-credential`
 
@@ -177,9 +182,14 @@ See the included [shell script](tests/example.sh).
 [vc-http-api]: https://w3c-ccg.github.io/vc-http-api/
 [RsaSignature2018]: https://w3c-ccg.github.io/lds-rsa2018/
 [Ed25519VerificationKey2018]: https://w3c-ccg.github.io/lds-ed25519-2018/
+[Ed25519]: https://tools.ietf.org/html/rfc8037#appendix-A.2
+[P-256]: https://tools.ietf.org/html/rfc7518#section-6.2.1.1
+[Secp256k1]: https://tools.ietf.org/html/rfc8812#section-3.1
 
 [did:key]: https://w3c-ccg.github.io/did-method-key/
 [did:web]: https://w3c-ccg.github.io/did-method-web/
+[did:tz]: https://did-tezos.spruceid.com/
+[did:ethr]: https://github.com/decentralized-identity/ethr-did-resolver/blob/master/doc/did-method-spec.md
 
 [proof options]: https://w3c-ccg.github.io/ld-proofs/#dfn-proof-options
 [ld-proofs-overview]: https://w3c-ccg.github.io/ld-proofs/#linked-data-proof-overview

--- a/lib/flutter/lib/didkit.dart
+++ b/lib/flutter/lib/didkit.dart
@@ -95,16 +95,16 @@ class DIDKit {
     return did_key_string;
   }
 
-  static String keyToDID(String methodName, String key) {
-    final did = key_to_did(Utf8.toUtf8(methodName), Utf8.toUtf8(key));
+  static String keyToDID(String methodPattern, String key) {
+    final did = key_to_did(Utf8.toUtf8(methodPattern), Utf8.toUtf8(key));
     if (did.address == nullptr.address) throw lastError();
     final did_string = Utf8.fromUtf8(did);
     free_string(did);
     return did_string;
   }
 
-  static String keyToVerificationMethod(String methodName, String key) {
-    final vm = key_to_verification_method(Utf8.toUtf8(methodName), Utf8.toUtf8(key));
+  static String keyToVerificationMethod(String methodPattern, String key) {
+    final vm = key_to_verification_method(Utf8.toUtf8(methodPattern), Utf8.toUtf8(key));
     if (vm.address == nullptr.address) throw lastError();
     final vm_string = Utf8.fromUtf8(vm);
     free_string(vm);

--- a/lib/java/main/com/spruceid/DIDKit.java
+++ b/lib/java/main/com/spruceid/DIDKit.java
@@ -5,8 +5,8 @@ import com.spruceid.DIDKitException;
 public class DIDKit {
     public static native String getVersion();
     public static native String generateEd25519Key() throws DIDKitException;
-    public static native String keyToDID(String methodName, String jwk) throws DIDKitException;
-    public static native String keyToVerificationMethod(String methodName, String jwk) throws DIDKitException;
+    public static native String keyToDID(String methodPattern, String jwk) throws DIDKitException;
+    public static native String keyToVerificationMethod(String methodPattern, String jwk) throws DIDKitException;
     public static native String issueCredential(String credential, String linkedDataProofOptions, String key) throws DIDKitException;
     public static native String verifyCredential(String verifiableCredential, String linkedDataProofOptions);
     public static native String issuePresentation(String presentation, String linkedDataProofOptions, String key) throws DIDKitException;

--- a/lib/node/native/src/didkit.rs
+++ b/lib/node/native/src/didkit.rs
@@ -28,37 +28,29 @@ pub fn generate_ed25519_key(mut cx: FunctionContext) -> JsResult<JsValue> {
 }
 
 pub fn key_to_did(mut cx: FunctionContext) -> JsResult<JsString> {
-    let did_method: String = arg!(cx, 0, String);
+    let method_pattern: String = arg!(cx, 0, String);
     let key: JWK = arg!(cx, 1, JWK);
 
-    let did_method = throws!(
-        cx,
-        DID_METHODS.get(&did_method).ok_or(DIDKitError::UnknownDIDMethod)
-    )?;
     let did = throws!(
         cx,
-        did_method
-            .generate(&Source::Key(&key))
+        DID_METHODS
+            .generate(&Source::KeyAndPattern(&key, &method_pattern))
             .ok_or(DIDKitError::UnableToGenerateDID)
     )?;
     Ok(cx.string(did))
 }
 
 pub fn key_to_verification_method(mut cx: FunctionContext) -> JsResult<JsString> {
-    let did_method: String = arg!(cx, 0, String);
+    let method_pattern: String = arg!(cx, 0, String);
     let key: JWK = arg!(cx, 1, JWK);
 
-    let did_method = throws!(
-        cx,
-        DID_METHODS.get(&did_method).ok_or(DIDKitError::UnknownDIDMethod)
-    )?;
     let did = throws!(
         cx,
-        did_method
-            .generate(&Source::Key(&key))
+        DID_METHODS
+            .generate(&Source::KeyAndPattern(&key, &method_pattern))
             .ok_or(DIDKitError::UnableToGenerateDID)
     )?;
-    let did_resolver = did_method.to_resolver();
+    let did_resolver = DID_METHODS.to_resolver();
     let rt = throws!(cx, runtime::get())?;
     let vm = throws!(
         cx,

--- a/lib/python/didkit/__init__.py
+++ b/lib/python/didkit/__init__.py
@@ -31,11 +31,11 @@ didkit.didkit_error_code.argtype = ()
 didkit.didkit_vc_generate_ed25519_key.restype = c_void_p
 didkit.didkit_vc_generate_ed25519_key.argtype = ()
 
-# String keyToDID(String methodName, String key)
+# String keyToDID(String methodPattern, String key)
 didkit.didkit_key_to_did.restype = c_void_p
 didkit.didkit_key_to_did.argtype = (c_char_p, c_char_p)
 
-# String keyToVerificationMethod(String methodName, String key)
+# String keyToVerificationMethod(String methodPattern, String key)
 didkit.didkit_key_to_verification_method.restype = c_void_p
 didkit.didkit_key_to_verification_method.argtype = (c_char_p, c_char_p)
 
@@ -98,8 +98,8 @@ def generateEd25519Key():
     return key_str
 
 
-def keyToDID(methodName, key):
-    did = didkit.didkit_key_to_did(methodName.encode(), key.encode())
+def keyToDID(methodPattern, key):
+    did = didkit.didkit_key_to_did(methodPattern.encode(), key.encode())
     if not did:
         raise DIDKitException.lastError()
     did_str = cast(did, c_char_p).value.decode()
@@ -107,8 +107,8 @@ def keyToDID(methodName, key):
     return did_str
 
 
-def keyToVerificationMethod(methodName, key):
-    vm = didkit.didkit_key_to_verification_method(methodName.encode(),
+def keyToVerificationMethod(methodPattern, key):
+    vm = didkit.didkit_key_to_verification_method(methodPattern.encode(),
                                                   key.encode())
     if not vm:
         raise DIDKitException.lastError()

--- a/lib/web/src/lib.rs
+++ b/lib/web/src/lib.rs
@@ -85,32 +85,26 @@ pub fn generateEd25519Key() -> Result<String, JsValue> {
     map_jsvalue(generate_ed25519_key())
 }
 
-fn key_to_did(method_name: String, jwk: String) -> Result<String, Error> {
+fn key_to_did(method_pattern: String, jwk: String) -> Result<String, Error> {
     let key: JWK = serde_json::from_str(&jwk)?;
-    let did_method = DID_METHODS
-        .get(&method_name)
-        .ok_or(Error::UnknownDIDMethod)?;
-    let did = did_method
-        .generate(&Source::Key(&key))
+    let did = DID_METHODS
+        .generate(&Source::KeyAndPattern(&key, &method_pattern))
         .ok_or(Error::UnableToGenerateDID)?;
     Ok(did)
 }
 
 #[wasm_bindgen]
 #[allow(non_snake_case)]
-pub fn keyToDID(method_name: String, jwk: String) -> Result<String, JsValue> {
-    map_jsvalue(key_to_did(method_name, jwk))
+pub fn keyToDID(method_pattern: String, jwk: String) -> Result<String, JsValue> {
+    map_jsvalue(key_to_did(method_pattern, jwk))
 }
 
-async fn key_to_verification_method(method_name: String, jwk: String) -> Result<String, Error> {
+async fn key_to_verification_method(method_pattern: String, jwk: String) -> Result<String, Error> {
     let key: JWK = serde_json::from_str(&jwk)?;
-    let did_method = DID_METHODS
-        .get(&method_name)
-        .ok_or(Error::UnknownDIDMethod)?;
-    let did = did_method
-        .generate(&Source::Key(&key))
+    let did = DID_METHODS
+        .generate(&Source::KeyAndPattern(&key, &method_pattern))
         .ok_or(Error::UnableToGenerateDID)?;
-    let did_resolver = did_method.to_resolver();
+    let did_resolver = DID_METHODS.to_resolver();
     let vm = get_verification_method(&did, did_resolver)
         .await
         .ok_or(Error::UnableToGetVerificationMethod)?;
@@ -119,8 +113,8 @@ async fn key_to_verification_method(method_name: String, jwk: String) -> Result<
 
 #[wasm_bindgen]
 #[allow(non_snake_case)]
-pub fn keyToVerificationMethod(method_name: String, jwk: String) -> Promise {
-    map_async_jsvalue(key_to_verification_method(method_name, jwk))
+pub fn keyToVerificationMethod(method_pattern: String, jwk: String) -> Promise {
+    map_async_jsvalue(key_to_verification_method(method_pattern, jwk))
 }
 
 #[cfg(any(


### PR DESCRIPTION
Change method name to method pattern for `key-to-did` and `key-to-verification-method` and corresponding FFI functions.

Method pattern is a generalization of method name that allows passing an additional string to the DID method by appending it to the DID method name, separated by a colon (`:`). This can be used to request generating a DID under a given prefix or other pattern if supported by the DID method.

Depends on: https://github.com/spruceid/ssi/pull/133

This is intended to enable https://github.com/spruceid/didkit/pull/115, to be used like this:
`didkit key-to-did pkh:tz`

This allows reusing the existing API.

An alternative would be to use a metadata/options structure, like this:
`didkit key-to-did pkh -i publicKeyHashName=tz`
That is more verbose, and would require changing the type signatures of the `keyToDID` and `keyToVerificationMethod` functions to add an additional options parameter. So instead I propose effectively allowing passing a single string to the DIDMethod's `generate` function, along with the public key, which can be used to request a prefix or pattern of the DID's [`method-specific-id`](https://w3c.github.io/did-core/#method-syntax), e.g. for use with `did-pkh` (https://github.com/spruceid/didkit/pull/115).