### PR TITLE
Hyphenate package names

### DIFF
--- a/lib/cbindings/Cargo.toml
+++ b/lib/cbindings/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "didkit_cbindings"
+name = "didkit-cbindings"
 version = "0.1.0"
 authors = ["Charles E. Lehner <charles.lehner@spruceid.com>"]
 edition = "2018"

--- a/lib/node/native/Cargo.toml
+++ b/lib/node/native/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "didkit_node"
+name = "didkit-node"
 version = "0.1.0"
 authors = ["Tiago Nascimento <tiago.nascimento@spruceid.com>"]
 build = "build.rs"


### PR DESCRIPTION
For consistency, update the `wasm` and `cbindings` package names to use hyphenation.
- `didkit_wasm` → `didkit-wasm`
- `didkit_cbindings` → `didkit-cbindings`