### PR TITLE
Add did:onion

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -21,6 +21,7 @@ did-ethr = { path = "../../ssi/did-ethr" }
 did-pkh = { path = "../../ssi/did-pkh" }
 did-sol = { path = "../../ssi/did-sol" }
 did-web = { path = "../../ssi/did-web" }
+did-onion = { path = "../../ssi/did-onion" }
 serde_json = "1.0"
 jni = "0.17"
 lazy_static = "1.4"

--- a/lib/src/did_methods.rs
+++ b/lib/src/did_methods.rs
@@ -1,5 +1,6 @@
 use did_ethr::DIDEthr;
 use did_method_key::DIDKey;
+use did_onion::DIDOnion;
 use did_pkh::DIDPKH;
 use did_sol::DIDSol;
 use did_tezos::DIDTz;
@@ -8,6 +9,7 @@ use ssi::did::DIDMethods;
 
 lazy_static! {
     static ref DIDTZ: DIDTz = DIDTz::default();
+    static ref DIDONION: DIDOnion = DIDOnion::default();
     pub static ref DID_METHODS: DIDMethods<'static> = {
         let mut methods = DIDMethods::default();
         methods.insert(&DIDKey);
@@ -16,6 +18,7 @@ lazy_static! {
         methods.insert(&DIDSol);
         methods.insert(&DIDWeb);
         methods.insert(&DIDPKH);
+        methods.insert(&*DIDONION);
         methods
     };
 }


### PR DESCRIPTION
Uses https://github.com/spruceid/ssi/pull/147

This should work, returning a DID document:
```
$ didkit did-resolve did:onion:fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid
```
~~Note that we cannot use the resulting DID document as-is, due to https://github.com/spruceid/ssi/issues/148. It might also be a problem that this particular DID document uses a property `VerificationMethod` instead of `verificationMethod`.~~ The document is fixed: https://github.com/spruceid/didkit/pull/125#issuecomment-810634276

This should fetch and verify a VC (Thanks @gorazdko for the example VC):
```
curl -sx socks5h://127.0.0.1:9050/ http://fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid.onion/vc_sw2.json | didkit vc-verify-credential
```

~~Should we test this live in CI, connecting to an onion service over Tor?~~ Won't be testing doing that, but may test with a mock interface, in https://github.com/spruceid/ssi/pull/147