### PR TITLE
Checkout ssi with submodules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
         repository: spruceid/ssi
         path: ssi
         ref: 7bf127e0065b2596885ed1cf3dd09dbaa863a887
+        submodules: true
 
     - name: Cache Cargo registry and build artifacts
       uses: actions/cache@v2

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -21,6 +21,7 @@ jobs:
       with:
         repository: spruceid/ssi
         path: didkit/ssi
+        submodules: true
 
     - name: Build and push CLI
       uses: elgohr/Publish-Docker-Github-Action@master


### PR DESCRIPTION
Fix #130

`ssi` since https://github.com/spruceid/ssi/pull/138 depends on a git submodule for `json_ld`