### PR TITLE
Prepare didkit crate for publishing to crates.io

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -3,6 +3,16 @@ name = "didkit"
 version = "0.1.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
+description = "Library for Verifiable Credentials and Decentralized Identifiers."
+license = "Apache-2.0"
+homepage = "https://spruceid.dev/docs/didkit/"
+repository = "https://github.com/spruceid/didkit/"
+documentation = "https://docs.rs/didkit/"
+keywords = ["ssi", "did"]
+
+include = [
+  "/src"
+]
 
 [features]
 default = ["ring", "secp256k1", "p256"]
@@ -14,14 +24,14 @@ p256 = ["ssi/p256", "did-tz/p256", "did-method-key/p256"]
 
 [dependencies]
 #didkit_cbindings = { path = "cbindings/" }
-ssi = { path = "../../ssi", default-features = false }
-did-method-key = { path = "../../ssi/did-key" }
-did-tz = { path = "../../ssi/did-tezos", default-features = false }
-did-ethr = { path = "../../ssi/did-ethr" }
-did-pkh = { path = "../../ssi/did-pkh" }
-did-sol = { path = "../../ssi/did-sol" }
-did-web = { path = "../../ssi/did-web" }
-did-onion = { path = "../../ssi/did-onion" }
+ssi = { version = "0.2", path = "../../ssi", default-features = false }
+did-method-key = { version = "0.1", path = "../../ssi/did-key" }
+did-tz = { version = "0.1", path = "../../ssi/did-tezos", default-features = false }
+did-ethr = { version = "0.0.1", path = "../../ssi/did-ethr" }
+did-pkh = { version = "0.0.1", path = "../../ssi/did-pkh" }
+did-sol = { version = "0.0.1", path = "../../ssi/did-sol" }
+did-web = { version = "0.1", path = "../../ssi/did-web" }
+did-onion = { version = "0.1", path = "../../ssi/did-onion" }
 serde_json = "1.0"
 jni = "0.17"
 lazy_static = "1.4"


### PR DESCRIPTION
Progress for #119

- Add package metadata.
- Include only the Rust source files in the crate, not all the other things in `/lib`.
- Depend on ssi crates using their `crates.io` registry versions.

Publish dry-run succeeds with this command:
```
$ cargo publish --dry-run --manifest-path lib/Cargo.toml
```