### PR TITLE
Enable secp256k1 and p256 by default

### DIFF
--- a/cli/tests/cli.rs
+++ b/cli/tests/cli.rs
@@ -4,6 +4,9 @@ use std::process::{Command, Stdio};
 
 static BIN: &str = env!("CARGO_BIN_EXE_didkit");
 
+const DID_KEY_K256: &'static str = "did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme";
+const DID_KEY_P256: &'static str = "did:key:zrurwcJZss4ruepVNu1H3xmSirvNbzgBk9qrCktB6kaewXnJAhYWwtP3bxACqBpzjZdN7TyHNzzGGSSH5qvZsSDir9z";
+
 #[test]
 fn generate_key() {
     Command::new(BIN)
@@ -146,6 +149,20 @@ fn didkit_cli() {
     assert_ne!(res_result["didResolutionMetadata"], Value::Null);
     assert_ne!(res_result["didDocumentMetadata"], Value::Null);
     assert_eq!(res_result["didResolutionMetadata"]["error"], Value::Null);
+
+    // Resolve more DIDs
+    let resolve = Command::new(BIN)
+        .args(&["did-resolve", DID_KEY_K256])
+        .stderr(Stdio::inherit())
+        .output()
+        .unwrap();
+    assert!(resolve.status.success());
+    let resolve = Command::new(BIN)
+        .args(&["did-resolve", DID_KEY_P256])
+        .stderr(Stdio::inherit())
+        .output()
+        .unwrap();
+    assert!(resolve.status.success());
 
     // Dereference a DID URL to a verification method
     let deref = Command::new(BIN)

--- a/http/tests/main.rs
+++ b/http/tests/main.rs
@@ -17,6 +17,9 @@ const DID_KEY_JSON: &'static str = include_str!("../../cli/tests/ed25519-key.jwk
 const DID_KEY: &'static str = "did:key:z6MkiVpwA241guqtKWAkohHpcAry7S94QQb6ukW3GcCsugbK";
 const VERIFICATION_METHOD: &'static str = "did:key:z6MkiVpwA241guqtKWAkohHpcAry7S94QQb6ukW3GcCsugbK#z6MkiVpwA241guqtKWAkohHpcAry7S94QQb6ukW3GcCsugbK";
 
+const DID_KEY_K256: &'static str = "did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme";
+const DID_KEY_P256: &'static str = "did:key:zrurwcJZss4ruepVNu1H3xmSirvNbzgBk9qrCktB6kaewXnJAhYWwtP3bxACqBpzjZdN7TyHNzzGGSSH5qvZsSDir9z";
+
 const ISSUE_CRED_REQ: &str = r#"{
     "credential": {
         "@context": "https://www.w3.org/2018/credentials/v1",
@@ -353,6 +356,14 @@ async fn resolve_dereference() {
     assert_eq!(result.did_document.unwrap().id, DID_KEY);
     assert_eq!(res_meta.content_type.unwrap(), TYPE_DID_LD_JSON);
     assert_eq!(http_content_type, TYPE_DID_RESOLUTION);
+
+    // Resolve more DIDs
+    let uri = Uri::from_str(&format!("{}/identifiers/{}", base, DID_KEY_K256)).unwrap();
+    let resp = client.get(uri).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let uri = Uri::from_str(&format!("{}/identifiers/{}", base, DID_KEY_P256)).unwrap();
+    let resp = client.get(uri).await.unwrap();
+    assert_eq!(resp.status(), 200);
 
     // Dereference DID URL
     let uri_string = format!(

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Spruce Systems, Inc."]
 edition = "2018"
 
 [features]
-default = ["ring"]
+default = ["ring", "secp256k1", "p256"]
 ring = ["ssi/ring"]
 wasm = []
 http-did = ["ssi/http-did"]


### PR DESCRIPTION
For #138, in order to provide the most functionality we can for the Universal Resolver, it would be useful to enable secp256k1 and p256 features for the `didkit-http` Docker image. As mentioned in https://github.com/spruceid/didkit/issues/138#issuecomment-816126213, these features are currently not enabled by default. I think it would be good to make these default features for `didkit`, `didkit-cli`, and `didkit-http`, so that users are not surprised by missing functionality. The features should remain opt-out-able via disabling `default-features`.