### PR TITLE
Move install from Python build to a new target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,4 +129,4 @@ jobs:
       run: make -C lib ../target/test/aar.stamp
 
     - name: Test Python Package
-      run: make -C lib ../target/test/python.stamp
+      run: make -C lib install-python

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -48,9 +48,12 @@ $(TARGET)/test/python.stamp: $(TARGET)/release/libdidkit.so | $(TARGET)/test
 	rm -rf python/dist/*
 	python3 -m pip install --upgrade pip build
 	python3 -m build python/
+	touch $@
+
+.PHONY: install-python
+install-python: $(TARGET)/test/python.stamp
 	python3 -m pip install python/dist/didkit-$(VERSION)-*.whl
 	python3 -m unittest python/didkit/tests.py -v
-	touch $@
 
 ## Java
 


### PR DESCRIPTION
Python build command no longer will install after build, instead a new target was added `install-python` which installs, and builds if not already, the wheel to the current `pip`.