### PR TITLE
didkit 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0] - 2021-04-12
 ### Added
 - Add Node.js package, using [Neon][].
 - Add WASM package, using [wasm-pack][].
@@ -85,5 +87,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [vc-http-api-test-server]: https://github.com/w3c-ccg/vc-http-api/tree/b4df10d/packages/vc-http-api-test-server
 [wasm-pack]: https://rustwasm.github.io/wasm-pack/
 
-[Unreleased]: https://github.com/spruceid/didkit/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/spruceid/didkit/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/spruceid/didkit/releases/tag/v0.2.0
 [0.1.0]: https://github.com/spruceid/didkit/releases/tag/v0.1.0

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -3,6 +3,16 @@ name = "didkit"
 version = "0.1.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
+description = "Library for Verifiable Credentials and Decentralized Identifiers."
+license = "Apache-2.0"
+homepage = "https://spruceid.dev/docs/didkit/"
+repository = "https://github.com/spruceid/didkit/"
+documentation = "https://docs.rs/didkit/"
+keywords = ["ssi", "did"]
+
+include = [
+  "/src"
+]
 
 [features]
 default = ["ring", "secp256k1", "p256"]
@@ -14,14 +24,14 @@ p256 = ["ssi/p256", "did-tz/p256", "did-method-key/p256"]
 
 [dependencies]
 #didkit_cbindings = { path = "cbindings/" }
-ssi = { path = "../../ssi", default-features = false }
-did-method-key = { path = "../../ssi/did-key" }
-did-tz = { path = "../../ssi/did-tezos", default-features = false }
-did-ethr = { path = "../../ssi/did-ethr" }
-did-pkh = { path = "../../ssi/did-pkh" }
-did-sol = { path = "../../ssi/did-sol" }
-did-web = { path = "../../ssi/did-web" }
-did-onion = { path = "../../ssi/did-onion" }
+ssi = { version = "0.2", path = "../../ssi", default-features = false }
+did-method-key = { version = "0.1", path = "../../ssi/did-key" }
+did-tz = { version = "0.1", path = "../../ssi/did-tezos", default-features = false }
+did-ethr = { version = "0.0.1", path = "../../ssi/did-ethr" }
+did-pkh = { version = "0.0.1", path = "../../ssi/did-pkh" }
+did-sol = { version = "0.0.1", path = "../../ssi/did-sol" }
+did-web = { version = "0.1", path = "../../ssi/did-web" }
+did-onion = { version = "0.1", path = "../../ssi/did-onion" }
 serde_json = "1.0"
 jni = "0.17"
 lazy_static = "1.4"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didkit"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 description = "Library for Verifiable Credentials and Decentralized Identifiers."

--- a/lib/python/setup.cfg
+++ b/lib/python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = didkit
-version = 0.1.0
+version = 0.2.0
 author = Spruce Systems, Inc.
 author_email = oss@spruceid.com
 description = DIDKit python package


### PR DESCRIPTION
Increment crate version and update changelog.

Includes #139

Also update the Python package version, since tests expect it to match the `didkit` crate's version.

Release command for publish to `crates.io` registry:
```
cargo publish --manifest-path lib/Cargo.toml
```

To be followed by creating a signed git tag including the content hash of the crate.