### PR TITLE
Update didkit-cli and didkit-http package metadata

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,6 +3,18 @@ name = "didkit-cli"
 version = "0.1.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
+description = "Command-line interface for Verifiable Credentials and Decentralized Identifiers."
+license = "Apache-2.0"
+license-file = "../LICENSE"
+keywords = ["ssi", "did", "vc", "cli"]
+categories = ["command-line-utilities"]
+homepage = "https://github.com/spruceid/didkit/tree/main/cli/"
+repository = "https://github.com/spruceid/didkit/"
+documentation = "https://docs.rs/didkit-cli/"
+
+exclude = [
+  "/tests"
+]
 
 [features]
 default = ["ring"]
@@ -11,12 +23,12 @@ ring = ["ssi/ring"]
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-didkit = { path = "../lib", features = ["http-did"] }
+didkit = { version = "0.2", path = "../lib", features = ["http-did"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 structopt = "0.3"
-did-method-key = { path = "../../ssi/did-key" }
-ssi = { path = "../../ssi", default-features = false }
+did-method-key = { version = "0.1", path = "../../ssi/did-key" }
+ssi = { version = "0.2", path = "../../ssi", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "process"] }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -3,14 +3,26 @@ name = "didkit-http"
 version = "0.1.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
+description = "HTTP server for Verifiable Credentials and Decentralized Identifiers."
+keywords = ["ssi", "did", "vc", "http", "api", "rest"]
+license = "Apache-2.0"
+license-file = "../LICENSE"
+categories = ["web-programming::http-server"]
+homepage = "https://github.com/spruceid/didkit/tree/main/http/"
+repository = "https://github.com/spruceid/didkit/"
+documentation = "https://docs.rs/didkit-http/"
+
+exclude = [
+  "/tests"
+]
 
 [features]
 default = ["ring"]
 ring = ["ssi/ring"]
 
 [dependencies]
-didkit = { path = "../lib", features = ["http-did"] }
-didkit-cli = { path = "../cli" }
+didkit = { version = "0.2", path = "../lib", features = ["http-did"] }
+didkit-cli = { version = "0.1", path = "../cli" }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 structopt = "0.3"
 serde = { version = "1.0", features = ["derive"] }
@@ -19,8 +31,8 @@ serde_urlencoded = "0.7"
 hyper = { version = "0.14", features = ["server", "client", "http1", "http2", "stream"] }
 tower-service = "0.3"
 futures-util = { version = "0.3", default-features = false }
-ssi = { path = "../../ssi", default-features = false }
+ssi = { version = "0.2", path = "../../ssi", default-features = false }
 percent-encoding = "2.1"
 
 [dev-dependencies]
-did-method-key = { path = "../../ssi/did-key" }
+did-method-key = { version = "0.1", path = "../../ssi/did-key" }


### PR DESCRIPTION
Prepare for publish to crates.io. Progress for #119

Update package metadata. Exclude tests directories to remove files not needed in the crate release.

Dry-run publish of didkit-cli succeeds. Files:
```
$ tar tzf target/package/didkit-cli-0.1.0.crate
didkit-cli-0.1.0/.cargo_vcs_info.json
didkit-cli-0.1.0/Cargo.lock
didkit-cli-0.1.0/Cargo.toml
didkit-cli-0.1.0/Cargo.toml.orig
didkit-cli-0.1.0/LICENSE
didkit-cli-0.1.0/README.md
didkit-cli-0.1.0/src/lib.rs
didkit-cli-0.1.0/src/main.rs
didkit-cli-0.1.0/src/opts.rs
```

`didkit-http` publish does not work yet because it depends on `didkit-cli` being published, but I've added the changes I expect will enable it to work otherwise.