### PR TITLE
Update ssi ref

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         repository: spruceid/ssi
         path: ssi
-        ref: 65036c6dfa005457cded27ee1358997b55da1924
+        ref: 7ce9d70a6fdfc92269e786417573780d0a47d4f7
         submodules: true
 
     - name: Cache Cargo registry and build artifacts


### PR DESCRIPTION
Update to use ssi v0.2.1 and did-method-key v0.1.1 in CI, to fix
`simple_asn1`/num-bigint type mismatch build failure seen in https://github.com/spruceid/didkit/runs/2451568678

Mentioned in https://github.com/spruceid/didkit/pull/155#issuecomment-828758249