### PR TITLE
Add did:webkey and sign with ssh-agent functionality

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         repository: spruceid/ssi
         path: ssi
-        ref: 2f07a6f0d9bdbcc33b2906d3b9a927480d86ead3
+        ref: b0900a6d0254caef457161d10653f3ac8f5138d3
         submodules: true
 
     - name: Cache Cargo registry and build artifacts
@@ -51,6 +51,9 @@ jobs:
 
     - name: Test CLI
       run: cli/tests/example.sh
+
+    - name: Test CLI with ssh-agent
+      run: cli/tests/ssh-agent.sh
 
     - name: Test HTTP server
       run: http/tests/example.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         repository: spruceid/ssi
         path: ssi
-        ref: b0900a6d0254caef457161d10653f3ac8f5138d3
+        ref: 2f07a6f0d9bdbcc33b2906d3b9a927480d86ead3
         submodules: true
 
     - name: Cache Cargo registry and build artifacts

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -29,6 +29,10 @@ serde_json = "1.0"
 structopt = "0.3"
 did-method-key = { version = "0.1", path = "../../ssi/did-key" }
 ssi = { version = "0.2", path = "../../ssi", default-features = false }
+thiserror = "1.0"
+bytes = "1.0"
+base64 = "0.12"
+sshkeys = "0.3"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "process"] }

--- a/cli/README.md
+++ b/cli/README.md
@@ -55,7 +55,11 @@ The proof type is set automatically based on the key file provided. JWK paramete
 #### Options
 
 - `-r, --did-resolver <url>` - [DID resolver HTTP(S) endpoint][did-resolution-https-binding], used for DID resolution and DID URL dereferencing for non-built-in DID Methods. Equivalent to environmental variable `DID_RESOLVER`.
-- `-k, --key-path <key>` (required, conflicts with jwk) - Filename of JWK for signing.
+- `-k, --key-path <file>` - Filename of JWK file for signing. Conflicts with `-j`.
+- `-j, --jwk <jwk>` - JWK for signing. Conflicts with `-k`.
+- `-S, --ssh-agent` - Use SSH agent for signing instead of JWK private key. See the section on SSH Agent below for more info.
+
+One of `-k` (`--key-path`), `-j` (`--jwk`) or `-S` (`--ssh-agent`) is required.
 
 The following options correspond to linked data [proof options][] as specified in [ld-proofs][] and [vc-http-api][]:
 
@@ -63,7 +67,6 @@ The following options correspond to linked data [proof options][] as specified i
 - `-c, --created <created>` - [created][] property of the proof. ISO8601 datetime. Defaults to the current time.
   time.
 - `-d, --domain <domain>` - [domain][] property of the proof
-- `-j, --jwk <jwk>` (required, conflicts with key-path) - JWK for signing.
 - `-p, --proof-purpose <proof-purpose>` [proofPurpose][] property of the proof.
 - `-v, --verification-method <verification-method>` [verificationMethod][]
   property of the proof. URI for proof verification information, e.g. a public key identifier.
@@ -72,6 +75,19 @@ The following options correspond to linked data [proof options][] as specified i
 
 - `RSA`
 - `OKP` (`curve`: `Ed25519`)
+
+#### SSH Agent
+
+DIDKit can use [SSH Agent][] for signing, as an alternative to signing with a JWK private key.
+If the `-S` (`--ssh-agent`) CLI option is used, DIDKit will attempt to connect to a local instance of `ssh-agent`, via the [UNIX socket][] refered to by environmental variable `SSH_AUTH_SOCK`, following the [SSH Agent Protocol][].
+
+##### Key selection
+
+When `-S` (`--ssh-agent`) is used, the JWK referred to by `-k` (`--key-file`) or `-j` (`--jwk`) is treated as a public key and used to select which key from SSH Agent to use for signing. If no JWK option is used, then the SSH Agent is expected to have only one key, and that key is used for signing.
+
+[SSH Agent]: https://en.wikipedia.org/wiki/Ssh-agent
+[UNIX socket]: https://en.wikipedia.org/wiki/Unix_domain_socket
+[SSH Agent Protocol]: https://datatracker.ietf.org/doc/html/draft-miller-ssh-agent-04
 
 ### `didkit vc-verify-credential`
 

--- a/cli/tests/ssh-agent.sh
+++ b/cli/tests/ssh-agent.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Example/test of using DIDKit with ssh-agent for signing
+cargo build -p didkit-cli
+cd "$(dirname "$0")"
+export PATH="$PWD/../../target/debug:$PATH"
+
+eval "$(ssh-agent -s)"
+for alg in ed25519 ecdsa; do
+	ssh-keygen -q -N '' -t $alg -f id_$alg
+	cut -f1 -d' ' id_$alg.pub
+	didkit ssh-pk-to-jwk "$(cat id_$alg.pub)" > pk_$alg
+	ssh-add -q id_$alg
+	did=$(didkit key-to-did key -k pk_$alg)
+	vm=$(didkit key-to-verification-method key -k pk_$alg)
+	didkit did-auth -h "$did" -v "$vm" -k pk_$alg --ssh-agent > didauth.jsonld
+	didkit vc-verify-presentation < didauth.jsonld; echo
+	rm id_$alg id_$alg.pub pk_$alg
+done
+ssh-agent -k
+# rsa is not tested because there is no generative DID method for it

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -41,6 +41,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 jni = "0.17"
 lazy_static = "1.4"
+thiserror = "1.0"
+base64 = "0.12"
+sshkeys = "0.3"
+bytes = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.0", features = ["rt-multi-thread"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -24,7 +24,7 @@ ring = ["ssi/ring"]
 wasm = []
 http-did = ["ssi/http-did"]
 secp256k1 = ["ssi/libsecp256k1", "did-tz/secp256k1", "did-method-key/secp256k1"]
-p256 = ["ssi/secp256r1", "did-tz/p256", "did-method-key/secp256r1"]
+p256 = ["ssi/secp256r1", "did-tz/p256", "did-webkey/p256", "did-method-key/secp256r1"]
 
 [dependencies]
 didkit-cbindings = { path = "cbindings/" }
@@ -35,6 +35,7 @@ did-ethr = { version = "0.0.1", path = "../../ssi/did-ethr" }
 did-pkh = { version = "0.0.1", path = "../../ssi/did-pkh" }
 did-sol = { version = "0.0.1", path = "../../ssi/did-sol" }
 did-web = { version = "0.1", path = "../../ssi/did-web" }
+did-webkey = { version = "0.1", path = "../../ssi/did-webkey" }
 did-onion = { version = "0.1", path = "../../ssi/did-onion" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/lib/src/did_methods.rs
+++ b/lib/src/did_methods.rs
@@ -5,6 +5,7 @@ use did_pkh::DIDPKH;
 use did_sol::DIDSol;
 use did_tz::DIDTz;
 use did_web::DIDWeb;
+use did_webkey::DIDWebKey;
 use ssi::did::DIDMethods;
 
 lazy_static! {
@@ -17,6 +18,7 @@ lazy_static! {
         methods.insert(&DIDEthr);
         methods.insert(&DIDSol);
         methods.insert(&DIDWeb);
+        methods.insert(&DIDWebKey);
         methods.insert(&DIDPKH);
         methods.insert(&*DIDONION);
         methods

--- a/lib/src/ssh_agent.rs
+++ b/lib/src/ssh_agent.rs
@@ -1,0 +1,323 @@
+use crate::LinkedDataProofOptions;
+use sshkeys::PublicKey;
+use ssi::jwk::{Algorithm, JWK};
+use ssi::ldp::LinkedDataProofs;
+use std::convert::TryFrom;
+use thiserror::Error;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
+
+/// Requests from client to agent
+/// <https://tools.ietf.org/html/draft-miller-ssh-agent-04#section-5.1>
+const SSH_AGENTC_SIGN_REQUEST: u8 = 13;
+const SSH_AGENTC_REQUEST_IDENTITIES: u8 = 11;
+
+/// Replies from agent to client
+const SSH_AGENT_FAILURE: u8 = 5;
+// const SSH_AGENT_SUCCESS: u8 = 6;
+const SSH_AGENT_IDENTITIES_ANSWER: u8 = 12;
+const SSH_AGENT_SIGN_RESPONSE: u8 = 14;
+
+/// Signature flags
+/// <https://datatracker.ietf.org/doc/html/draft-miller-ssh-agent-04#section-5.3>
+const SSH_AGENT_RSA_SHA2_256: u32 = 2;
+const SSH_AGENT_RSA_SHA2_512: u32 = 4;
+
+#[derive(Error, Debug)]
+pub enum SignError {
+    #[error("Read: {0}")]
+    Read(#[from] ReadError),
+    #[error("Send: {0}")]
+    Send(#[from] SendError),
+    #[error("List keys: {0}")]
+    ListKeys(#[from] ListKeysError),
+    #[error("No keys")]
+    NoKeys,
+    #[error("Too many keys")]
+    TooManyKeys,
+    #[error("Signature request failed")]
+    SignatureRequestFailed,
+    #[error("Signature algorithm '{0}' not valid for JWS algorithm '{1:?}'")]
+    SignatureAlgorithmMismatch(String, Algorithm),
+    #[error("Unexpected reply to signature request: {0}")]
+    UnexpectedAnswer(u8),
+    #[error("Length conversion: {0}")]
+    TryFromInt(#[from] core::num::TryFromIntError),
+    #[error("Try from slice: {0}")]
+    TryFromSlice(#[from] core::array::TryFromSliceError),
+    #[error("Signature Utf8: {0}")]
+    FromUtf8Error(#[from] std::string::FromUtf8Error),
+    #[error("SSH parsing: {0}")]
+    SshParsing(#[from] sshkeys::Error),
+    #[error("Unsupported signing input format")]
+    UnsupportedSigningInputFormat,
+    #[error("Unsupported JWS algorithm: {0:?}")]
+    UnsupportedAlgorithm(Algorithm),
+    #[error("Unable to get JWS algorithm")]
+    MissingAlgorithm,
+    #[error("Unable to convert SSH Key To JWK: {0}")]
+    SSHKeyToJWKError(#[from] ssi::ssh::SSHKeyToJWKError),
+    #[error("Unable to calculate JWK thumbprint: {0}")]
+    JWKThumbprint(String),
+    #[error("Unable to prepare proof: {0}")]
+    Prep(#[from] ssi::error::Error),
+    #[error("RSA key must be at least 2048 bits")]
+    RSAKeyTooSmall,
+}
+
+#[derive(Error, Debug)]
+pub enum SendError {
+    #[error("IO error: {0}")]
+    IO(#[from] std::io::Error),
+    #[error("Length mismatch")]
+    LengthMismatch,
+    #[error("Length conversion: {0}")]
+    TryFromInt(#[from] core::num::TryFromIntError),
+}
+
+#[derive(Error, Debug)]
+pub enum ReadError {
+    #[error("IO: {0}")]
+    IO(#[from] std::io::Error),
+    #[error("Length conversion: {0}")]
+    TryFromInt(#[from] core::num::TryFromIntError),
+}
+
+#[derive(Error, Debug)]
+pub enum ListKeysError {
+    #[error("Send: {0}")]
+    Send(#[from] SendError),
+    #[error("Read: {0}")]
+    Read(#[from] ReadError),
+    #[error("IO error: {0}")]
+    IO(#[from] std::io::Error),
+    #[error("Unexpected reply to key list request: {0}")]
+    UnexpectedAnswer(u8),
+    #[error("Length conversion: {0}")]
+    TryFromInt(#[from] core::num::TryFromIntError),
+    #[error("Try from slice: {0}")]
+    TryFromSlice(#[from] core::array::TryFromSliceError),
+    #[error("Comment Utf8: {0}")]
+    FromUtf8Error(#[from] std::string::FromUtf8Error),
+    #[error("SSH parsing: {0}")]
+    SshParsing(#[from] sshkeys::Error),
+}
+
+#[derive(Debug)]
+struct Message {
+    pub type_: u8,
+    pub contents: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+struct SSHKey {
+    pub comment: String,
+    pub key_blob: Vec<u8>,
+    pub key_type: String,
+}
+
+async fn read_msg(ssh_agent_sock: &mut tokio::net::UnixStream) -> Result<Message, ReadError> {
+    use bytes::BytesMut;
+    let len = ssh_agent_sock.read_u32().await?;
+    let msg_type = ssh_agent_sock.read_u8().await?;
+    let len = usize::try_from(len)? - 1;
+    let mut contents = BytesMut::with_capacity(len);
+    let mut remaining = len;
+    while remaining > 0 {
+        let read = ssh_agent_sock.read_buf(&mut contents).await?;
+        remaining -= read;
+    }
+    Ok(Message {
+        type_: msg_type,
+        contents: contents.to_vec(),
+    })
+}
+
+async fn send_msg(
+    ssh_agent_sock: &mut tokio::net::UnixStream,
+    msg: Message,
+) -> Result<(), SendError> {
+    let len = u32::try_from(msg.contents.len())? + 1;
+    ssh_agent_sock.write_u32(len).await?;
+    ssh_agent_sock.write_u8(msg.type_).await?;
+    ssh_agent_sock.write_all(&msg.contents).await?;
+    Ok(())
+}
+
+async fn list_keys(
+    ssh_agent_sock: &mut tokio::net::UnixStream,
+) -> Result<Vec<PublicKey>, ListKeysError> {
+    send_msg(
+        ssh_agent_sock,
+        Message {
+            type_: SSH_AGENTC_REQUEST_IDENTITIES,
+            contents: Vec::new(),
+        },
+    )
+    .await?;
+    let reply = read_msg(ssh_agent_sock).await?;
+    if reply.type_ != SSH_AGENT_IDENTITIES_ANSWER {
+        return Err(ListKeysError::UnexpectedAnswer(reply.type_));
+    }
+    let mut reader = sshkeys::Reader::new(&reply.contents);
+    let nkeys = usize::try_from(reader.read_u32()?)?;
+    let mut keys = Vec::with_capacity(nkeys);
+    let mut remaining = nkeys;
+    while remaining > 0 {
+        let key_blob = reader.read_bytes()?;
+        let comment = reader.read_string()?;
+        let mut key = PublicKey::from_bytes(&key_blob)?;
+        key.comment = Some(comment);
+        keys.push(key);
+        remaining -= 1;
+    }
+
+    Ok(keys)
+}
+
+/// Return the first SSH public key that matches a given JWK
+fn select_key(keys: Vec<PublicKey>, jwk: Option<&JWK>) -> Result<(JWK, PublicKey), SignError> {
+    let jwk = match jwk {
+        Some(jwk) => jwk,
+        None => {
+            if keys.len() > 1 {
+                return Err(SignError::TooManyKeys);
+            }
+            let pk = keys.into_iter().next().ok_or(SignError::NoKeys)?;
+            let jwk = ssi::ssh::ssh_pkk_to_jwk(&pk.kind)?;
+            return Ok((jwk, pk));
+        }
+    };
+    let thumbprint = jwk
+        .thumbprint()
+        .map_err(|e| SignError::JWKThumbprint(e.to_string()))?;
+    for pk in keys {
+        let sshkey_jwk = ssi::ssh::ssh_pkk_to_jwk(&pk.kind)?;
+        let sshkey_thumbprint = sshkey_jwk
+            .thumbprint()
+            .map_err(|e| SignError::JWKThumbprint(e.to_string()))?;
+        if sshkey_thumbprint == thumbprint {
+            return Ok((sshkey_jwk, pk));
+        }
+    }
+    Err(SignError::NoKeys)
+}
+
+async fn sign(
+    ssh_agent_sock: &mut tokio::net::UnixStream,
+    pk: &sshkeys::PublicKey,
+    signing_input: &[u8],
+    alg: Algorithm,
+) -> Result<Vec<u8>, SignError> {
+    if pk.key_type.kind == sshkeys::KeyTypeKind::Rsa && pk.bits() < 2048 {
+        // RSA key size must be 2048 bits or larger.
+        // https://datatracker.ietf.org/doc/html/rfc7518#section-3.3
+        return Err(SignError::RSAKeyTooSmall);
+    }
+    let mut writer = sshkeys::Writer::new();
+    writer.write_bytes(&pk.encode());
+    writer.write_bytes(signing_input);
+    // writer doesn't have write_u32
+    let mut flags: u32 = 0;
+    // Without flag, signature type for RSA is "ssh-rsa" which uses SHA-1, and is deprecated:
+    // https://datatracker.ietf.org/doc/html/rfc4253#page-15
+    // https://www.openssh.com/txt/release-8.2
+    match alg {
+        Algorithm::RS256 => {
+            flags |= SSH_AGENT_RSA_SHA2_256;
+        }
+        Algorithm::RS512 => {
+            flags |= SSH_AGENT_RSA_SHA2_512;
+        }
+        Algorithm::EdDSA => {}
+        Algorithm::ES256 => {}
+        // Algorithm::ES384 => {}
+        // Algorithm::ES512 => {}
+        alg => {
+            return Err(SignError::UnsupportedAlgorithm(alg));
+        }
+    }
+    let flag_bytes = flags.to_be_bytes().to_vec();
+    let sign_req_bytes = [
+        // string  key blob
+        // string  data
+        writer.into_bytes(),
+        // uint32  flags
+        flag_bytes,
+    ]
+    .concat();
+    send_msg(
+        ssh_agent_sock,
+        Message {
+            type_: SSH_AGENTC_SIGN_REQUEST,
+            contents: sign_req_bytes,
+        },
+    )
+    .await?;
+    let reply = read_msg(ssh_agent_sock).await?;
+    match reply.type_ {
+        SSH_AGENT_FAILURE => {
+            return Err(SignError::SignatureRequestFailed);
+        }
+        SSH_AGENT_SIGN_RESPONSE => (),
+        type_ => {
+            return Err(SignError::UnexpectedAnswer(type_));
+        }
+    };
+    let mut reader = sshkeys::Reader::new(&reply.contents);
+    let bytes = reader.read_bytes()?;
+    let mut reader = sshkeys::Reader::new(&bytes);
+    let sig_type = reader.read_string()?;
+    // Verify that sig type corresponds with verification method / public key type
+    // https://datatracker.ietf.org/doc/html/rfc7518#section-3.1
+    // https://www.iana.org/assignments/ssh-parameters/ssh-parameters.xhtml#ssh-parameters-19
+    match (&sig_type[..], alg) {
+        // https://datatracker.ietf.org/doc/html/rfc8332#section-3
+        ("rsa-sha2-256", Algorithm::RS256) => {}
+        ("rsa-sha2-512", Algorithm::RS512) => {}
+        // https://datatracker.ietf.org/doc/html/rfc8709#section-6
+        ("ssh-ed25519", Algorithm::EdDSA) => {}
+        // https://datatracker.ietf.org/doc/html/rfc5656#section-6.2
+        ("ecdsa-sha2-nistp256", Algorithm::ES256) => {}
+        // ("ecdsa-sha2-nistp384", Algorithm::ES384) => {}
+        // ("ecdsa-sha2-nistp521", Algorithm::ES512) => {}
+        _ => {
+            return Err(SignError::SignatureAlgorithmMismatch(sig_type, alg));
+        }
+    }
+    let mut sig = reader.read_bytes()?;
+    if sig_type.starts_with("ecdsa-sha2-") {
+        let mut reader = sshkeys::Reader::new(&sig);
+        // https://datatracker.ietf.org/doc/html/rfc4251#page-9
+        // https://datatracker.ietf.org/doc/html/rfc5656#section-3.1.2
+        let r = reader.read_mpint()?;
+        let s = reader.read_mpint()?;
+        // https://docs.rs/ecdsa/0.11.0/ecdsa/struct.Signature.html
+        sig = [r, s].concat();
+    }
+    Ok(sig)
+}
+
+/// Generate Linked Data Proof over Document using signature from SSH Agent.
+pub async fn generate_proof(
+    ssh_agent_sock: &mut tokio::net::UnixStream,
+    document: &(dyn ssi::ldp::LinkedDataDocument + Sync),
+    options: LinkedDataProofOptions,
+    jwk_opt: Option<&JWK>,
+) -> Result<ssi::vc::Proof, SignError> {
+    let keys = list_keys(ssh_agent_sock).await?;
+    let (jwk, pk) = select_key(keys, jwk_opt)?;
+    let prep = LinkedDataProofs::prepare(document, &options, &jwk).await?;
+    let signing_input_bytes = match prep.signing_input {
+        ssi::ldp::SigningInput::Bytes(ref bytes) => bytes.0.to_vec(),
+        _ => Err(SignError::UnsupportedSigningInputFormat)?,
+    };
+    let alg = match prep.jws_header {
+        Some(ref header) => header.algorithm,
+        None => jwk.get_algorithm().ok_or(SignError::MissingAlgorithm)?,
+    };
+    let sig = sign(ssh_agent_sock, &pk, &signing_input_bytes, alg).await?;
+    let sig_b64 = base64::encode_config(sig, base64::URL_SAFE_NO_PAD);
+    let proof = prep.complete(&sig_b64).await?;
+    Ok(proof)
+}


### PR DESCRIPTION
Close #154

Depends on: https://github.com/spruceid/ssi/pull/178

- [x] Get socket path
- [x] Connect to socket
- [x] List keys in agent
- [x] Pick key in agent to use
- [x] Request signature from agent
- [x] Apply signature to proof
- [x] Reuse mechanism for all issue/sign commands
- [x] Consider changes in ssi
- [x] Document feature in README(s)
- [x] Make error messages helpful
- [x] Tests (partial)

### Future work
- #173 
- #174