### PR TITLE
Cross compile instructions and python package publish instructions

### DIFF
--- a/CROSS.md
+++ b/CROSS.md
@@ -1,0 +1,69 @@
+# MacOS
+### References were taken from [this](https://wapl.es/rust/2019/02/17/rust-cross-compile-linux-to-macos.html) article.
+
+Dependencies and cross-compiler:
+```bash
+$ sudo apt install clang cmake git patch libssl-dev lzma-dev \ 
+		gcc g++ zlib1g-dev libmpc-dev libmpfr-dev \ 
+		libgmp-dev libxml2-dev
+$ rustup target add x86_64-apple-darwin
+$ git clone https://github.com/tpoechtrager/osxcross
+$ cd osxcross
+$ wget -nc https://s3.dockerproject.org/darwin/v2/MacOSX10.10.sdk.tar.xz
+$ mv MacOSX10.10.sdk.tar.xz tarballs/
+```
+
+
+Make sure to have CMake >= 3.2.3:
+```bash
+$ UNATTENDED=yes OSX_VERSION_MIN=10.7 ./build.sh
+```
+
+Add `osxcross/target/bin` to your `$PATH`, replace `$OSX_CROSS_LOCATION` with 
+the path of your instalation.
+```bash
+    export PATH="$PATH:$OSX_CROSS_LOCATION/target/bin"
+```
+
+Add to `~/.cargo/config`
+```toml
+[target.x86_64-apple-darwin]
+  linker = "x86_64-apple-darwin14-clang"
+  ar = "x86_64-apple-darwin14-ar"
+```
+
+Compile with:
+```bash
+$ CC=o64-clang \
+  CXX=o64-clang++ \
+  MACOSX_DEPLOYMENT_TARGET=10.7 \
+  cargo build --lib --release \
+    --target x86_64-apple-darwin
+```
+
+## Known issues
+I can't run the build script from `osxcross`:
+
+ - Make sure to have CMake >= 3.2.3
+
+My compilation is failing with:
+```
+was built for newer macOS version (10.7) than being linked (10.6)
+```
+ - Change the `MACOSX_DEPLOYMENT_TARGET` flag to the correct version of your
+  osxcross
+
+# Windows
+Dependencies and cross-compiler:
+```bash
+$ sudo apt install mingw-w64
+$ rustup target add x86_64-pc-windows-gnu
+```
+
+Compile with:
+```bash
+$ CC=x86_64-w64-mingw32-gcc \
+  CXX=x86_64-w64-mingw32-g++ \
+  cargo build --lib --release \
+    --target x86_64-pc-windows-gnu
+```

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ $ docker build -f Dockerfile-http . -t didkit-http
 
 And to use them, replace `ghcr.io/spruceid/didkit-(cli|http):latest` with `didkit-(cli|http)`.
 
+## Cross compiling
+
+Information about how to cross compile DIDKit from linux to other platforms can
+be found [here](CROSS.md).
+
 ## Usage
 
 DIDKit can be used in any of the following ways:

--- a/lib/python/README.md
+++ b/lib/python/README.md
@@ -34,6 +34,47 @@ Install the package
 python3 -m pip install dist/didkit-`cat setup.cfg | grep version | cut -d' ' -f3`-*.whl
 ```
 
+## Publishing
+### **OBS: After each platform build the folders _`build/`_ and _`didkit.egg-info`_ must be removed, otherwise the previous builds binaries are included in the new wheel.**
+
+Refeer to [cross compile](/CROSS.md) for information on how to build from linux
+to other platforms.
+
+
+```bash
+python3 setup.py bdist_wheel -p $PLATFORM
+```
+
+Valid values for `$PLATFORM` are the following:
+ - `manylinux_GLIBCMAJOR_GLIBCMINOR_ARCH` for linux builds
+ - `macosx-10.MACOSX_DEPLOYMENT_TARGET_ARCH` for macOS builds
+ - `win-amd64` for Windows builds
+
+`GLIBC` version can be found running `ldd --version` at the shell, `ARCH` can be
+found running `uname -a`.
+
+Example publishing from linux for linux:
+```bash
+ldd --version
+ldd (Ubuntu GLIBC 2.31-0ubuntu9.2) 2.31
+uname -a
+x86_64 x86_64 x86_64 GNU/Linux
+python3 setup.py bdist_wheel -p manylinux_2_31-x86_64
+```
+
+Example publishing from linux for macOS:
+ - `MACOSX_DEPLOYMENT_TARGET=10.10` (this is set when buildng for mac)
+```bash
+uname -a
+x86_64
+python3 setup.py bdist_wheel -p macosx.10.10-x86_64
+```
+
+Example publishing from linux for Windows:
+```bash
+python3 setup.py bdist_wheel -p win-amd64
+```
+
 ## Maturity Disclaimer
 In the v0.1 release on January 27th, 2021, DIDKit has not yet undergone a
 formal security audit and to desired levels of confidence for suitable use in

--- a/lib/python/didkit/__init__.py
+++ b/lib/python/didkit/__init__.py
@@ -12,7 +12,7 @@ elif platform == "darwin":
     didpath = os.path.join(didpath, 'libdidkit.dylib')
     didkit = libc = CDLL(didpath)
 else:
-    didpath = os.path.join(didpath, 'libdidkit.dll')
+    didpath = os.path.join(didpath, 'didkit.dll')
     didkit = libc = CDLL(didpath, winmode=1)
 
 # String getVersion()

--- a/lib/python/didkit/didkit.dll
+++ b/lib/python/didkit/didkit.dll
@@ -1,0 +1,1 @@
+../../../target/release/didkit.dll

--- a/lib/python/didkit/libdidkit.dll
+++ b/lib/python/didkit/libdidkit.dll
@@ -1,1 +1,0 @@
-../../../target/release/libdidkit.dll

--- a/lib/python/setup.cfg
+++ b/lib/python/setup.cfg
@@ -10,14 +10,15 @@ url = https://github.com/spruceid/didkit
 project_urls =
     Bug Tracker = https://github.com/spruceid/didkit/issues
 classifiers =
+    Development Status :: 3 - Alpha
     Programming Language :: Python :: 3
     License :: OSI Approved :: Apache Software License
-    Operating System :: OS Independent
+    Operating System :: Microsoft
+    Operating System :: MacOS
+    Operating System :: POSIX
+
+include_package_data = True
 
 [options]
 packages = find:
-include_package_data = True
 python_requires = >=3.6
-
-[options.data_files]
-didkit = didkit/libdidkit.so

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -1,0 +1,17 @@
+from setuptools import setup, find_packages
+import sys
+
+lib_name = ''
+plat = ''
+if "linux" in sys.argv[-1]:
+    lib_name = "libdidkit.so"
+elif "macosx" in sys.argv[-1]:
+    lib_name = "libdidkit.dylib"
+elif "win" in sys.argv[-1]:
+    lib_name = "didkit.dll"
+else:
+    quit()
+
+setup(
+    package_data={'didkit': [lib_name]}
+)

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -9,8 +9,6 @@ elif "macosx" in sys.argv[-1]:
     lib_name = "libdidkit.dylib"
 elif "win" in sys.argv[-1]:
     lib_name = "didkit.dll"
-else:
-    quit()
 
 setup(
     package_data={'didkit': [lib_name]}


### PR DESCRIPTION
@theosirian 

This adds some instructions on how to build DIDKit from linux to macOS and Windows 64. This also adds some changes to the python package in order to ship the correct binaries to each platform and instructions on how to do it.

```bash
python3 -m pip install didkit
```