### PR TITLE
Fix build on apple platforms and fix ios release builds

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -27,7 +27,7 @@ secp256k1 = ["ssi/libsecp256k1", "did-tz/secp256k1", "did-method-key/secp256k1"]
 p256 = ["ssi/p256", "did-tz/p256", "did-method-key/p256"]
 
 [dependencies]
-#didkit_cbindings = { path = "cbindings/" }
+didkit-cbindings = { path = "cbindings/" }
 ssi = { version = "0.2", path = "../../ssi", default-features = false }
 did-method-key = { version = "0.1", path = "../../ssi/did-key" }
 did-tz = { version = "0.1", path = "../../ssi/did-tezos", default-features = false }

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -149,7 +149,7 @@ $(TARGET)/%/release/libdidkit.a: $(RUST_SRC)
 ## Flutter
 
 $(TARGET)/test/flutter.stamp: flutter/lib/didkit.dart flutter/test/didkit_test.dart $(TARGET)/release/$(LIB_NAME) | $(TARGET)/test
-	cd flutter && LD_LIBRARY_PATH=$(shell pwd) \
+	cd flutter && LD_LIBRARY_PATH=$(shell pwd)/flutter \
 		flutter --suppress-analytics test
 	touch $@
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -7,6 +7,12 @@ else
 	OS_NAME=$(shell uname | tr '[:upper:]' '[:lower:]')
 endif
 
+ifeq ($(OS_NAME),darwin)
+	LIB_NAME=libdidkit.dylib
+else 
+	LIB_NAME=libdidkit.so
+endif
+
 VERSION=$(shell cat Cargo.toml | grep -m 1 version | cut -d' ' -f3 | sed 's/"//g')
 
 .PHONY: test
@@ -27,16 +33,16 @@ android/res $(TARGET)/test $(TARGET)/jvm:
 RUST_SRC=Cargo.toml $(wildcard src/*.rs src/*/*.rs src/*/*/*.rs)
 
 $(TARGET)/didkit.h: cbindgen.toml cbindings/build.rs cbindings/Cargo.toml $(RUST_SRC)
-	cargo build -p didkit_cbindings
+	cargo build -p didkit-cbindings
 	test -s $@ && touch $@
 
-$(TARGET)/release/libdidkit.so: $(RUST_SRC)
+$(TARGET)/release/$(LIB_NAME): $(RUST_SRC)
 	cargo build --lib --release
-	strip $@
+	strip $@ || true
 
 ## C
 
-$(TARGET)/test/c.stamp: $(TARGET)/cabi-test $(TARGET)/release/libdidkit.so | $(TARGET)/test
+$(TARGET)/test/c.stamp: $(TARGET)/cabi-test $(TARGET)/release/$(LIB_NAME) | $(TARGET)/test
 	LD_LIBRARY_PATH=$(TARGET)/release $(TARGET)/cabi-test
 	touch $@
 
@@ -44,7 +50,7 @@ $(TARGET)/cabi-test: c/test.c $(TARGET)/release/libdidkit.so $(TARGET)/didkit.h
 	$(CC) -I$(TARGET) -L$(TARGET)/release $< -ldl -ldidkit -o $@
 
 ## Python
-$(TARGET)/test/python.stamp: $(TARGET)/release/libdidkit.so | $(TARGET)/test
+$(TARGET)/test/python.stamp: $(TARGET)/release/$(LIB_NAME) | $(TARGET)/test
 	rm -rf python/dist/*
 	python3 -m pip install --upgrade pip build
 	python3 -m build python/
@@ -63,7 +69,7 @@ $(TARGET)/test/java.stamp: \
 	$(TARGET)/jvm/com/spruceid/DIDKit.class \
 	$(TARGET)/jvm/com/spruceid/DIDKitException.class \
 	$(TARGET)/jvm/com/spruceid/DIDKitTest.class \
-	$(TARGET)/release/libdidkit.so | $(TARGET)/test
+	$(TARGET)/release/$(LIB_NAME) | $(TARGET)/test
 	java -Djava.class.path=$(TARGET)/jvm \
 		-Djava.library.path=$(TARGET)/release \
 		com.spruceid.DIDKitTest
@@ -129,7 +135,7 @@ IOS_LIBS=\
 	$(TARGET)/aarch64-apple-ios/release/libdidkit.a \
 	$(TARGET)/x86_64-apple-ios/release/libdidkit.a
 
-$(TARGET)/test/ios.stamp: $(TARGET)/universal/release/libdidkit.a | $(TARGET)/test
+$(TARGET)/test/ios.stamp: $(TARGET)/universal/release/libdidkit.a $(TARGET)/didkit.h | $(TARGET)/test
 	touch $@
 
 $(TARGET)/universal/release/libdidkit.a: $(IOS_LIBS)
@@ -138,12 +144,12 @@ $(TARGET)/universal/release/libdidkit.a: $(IOS_LIBS)
 
 $(TARGET)/%/release/libdidkit.a: $(RUST_SRC)
 	cargo build --lib --release --target $*
-	#$(TOOLCHAIN)/bin/llvm-strip $@
+	#strip $@
 
 ## Flutter
 
-$(TARGET)/test/flutter.stamp: flutter/lib/didkit.dart flutter/test/didkit_test.dart $(TARGET)/release/libdidkit.so | $(TARGET)/test
-	cd flutter && LD_LIBRARY_PATH=$$PWD \
+$(TARGET)/test/flutter.stamp: flutter/lib/didkit.dart flutter/test/didkit_test.dart $(TARGET)/release/$(LIB_NAME) | $(TARGET)/test
+	cd flutter && LD_LIBRARY_PATH=$(shell pwd) \
 		flutter --suppress-analytics test
 	touch $@
 

--- a/lib/flutter/ios/Classes/DIDKitFlutterPlugin.m
+++ b/lib/flutter/ios/Classes/DIDKitFlutterPlugin.m
@@ -3,9 +3,24 @@
 #import "didkit.h"
 
 @implementation DIDKitFlutterPlugin
-+ (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
-}
-+ (void)dummyMethodToEnforceBuilding {
++ (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {}
+
++ (void)dummyMethodToEnforceFunctionsDontGetOptmized {
+  // Here we MUST call all functions from didkit.h so that they don't get 
+  // optimized and removed from release builds.
   didkit_get_version();
+  didkit_did_auth(NULL, NULL, NULL);
+  didkit_did_resolve(NULL, NULL);
+  didkit_did_url_dereference(NULL, NULL);
+  didkit_error_code();
+  didkit_error_message();
+  didkit_free_string(NULL);
+  didkit_key_to_did(NULL, NULL);
+  didkit_key_to_verification_method(NULL, NULL);
+  didkit_vc_generate_ed25519_key();
+  didkit_vc_issue_credential(NULL, NULL, NULL);
+  didkit_vc_issue_presentation(NULL, NULL, NULL);
+  didkit_vc_verify_credential(NULL, NULL);
+  didkit_vc_verify_presentation(NULL, NULL);
 }
 @end

--- a/lib/flutter/lib/didkit.dart
+++ b/lib/flutter/lib/didkit.dart
@@ -4,10 +4,12 @@ import 'dart:ffi';
 import 'dart:io';
 import 'package:ffi/ffi.dart';
 
-// TODO: support macOS, Windows
+// TODO: support Windows
 final DynamicLibrary lib = Platform.isAndroid || Platform.isLinux
     ? DynamicLibrary.open('libdidkit.so')
-    : DynamicLibrary.process();
+    : Platform.isMacOS
+        ? DynamicLibrary.open('libdidkit.dylib')
+        : DynamicLibrary.process();
 
 final get_version =
     lib.lookupFunction<Pointer<Utf8> Function(), Pointer<Utf8> Function()>(

--- a/lib/flutter/libdidkit.dylib
+++ b/lib/flutter/libdidkit.dylib
@@ -1,0 +1,1 @@
+../../target/release/libdidkit.dylib

--- a/lib/flutter/test/didkit_test.dart
+++ b/lib/flutter/test/didkit_test.dart
@@ -11,10 +11,14 @@ void main() {
   });
 
   test('exceptions', () async {
-    expect(() => DIDKit.issueCredential('', '', ''), throwsA(isInstanceOf<DIDKitException>()));
-    expect(() => DIDKit.issuePresentation('', '', ''), throwsA(isInstanceOf<DIDKitException>()));
-    expect(() => DIDKit.verifyCredential('', ''), throwsA(isInstanceOf<DIDKitException>()));
-    expect(() => DIDKit.verifyPresentation('', ''), throwsA(isInstanceOf<DIDKitException>()));
+    expect(() => DIDKit.issueCredential('', '', ''),
+        throwsA(isInstanceOf<DIDKitException>()));
+    expect(() => DIDKit.issuePresentation('', '', ''),
+        throwsA(isInstanceOf<DIDKitException>()));
+    expect(() => DIDKit.verifyCredential('', ''),
+        throwsA(isInstanceOf<DIDKitException>()));
+    expect(() => DIDKit.verifyPresentation('', ''),
+        throwsA(isInstanceOf<DIDKitException>()));
   });
 
   test('generateEd25519Key', () async {
@@ -38,25 +42,23 @@ void main() {
     final did = DIDKit.keyToDID('key', key);
     final verificationMethod = DIDKit.keyToVerificationMethod('key', key);
     final options = {
-        'proofPurpose': 'assertionMethod',
-        'verificationMethod': verificationMethod
+      'proofPurpose': 'assertionMethod',
+      'verificationMethod': verificationMethod
     };
     final credential = {
-        '@context': 'https://www.w3.org/2018/credentials/v1',
-        'id': 'http://example.org/credentials/3731',
-        'type': ['VerifiableCredential'],
-        'issuer': did,
-        'issuanceDate': '2020-08-19T21:41:50Z',
-        'credentialSubject': {
-           'id': 'did:example:d23dd687a7dc6787646f2eb98d0'
-        }
+      '@context': 'https://www.w3.org/2018/credentials/v1',
+      'id': 'http://example.org/credentials/3731',
+      'type': ['VerifiableCredential'],
+      'issuer': did,
+      'issuanceDate': '2020-08-19T21:41:50Z',
+      'credentialSubject': {'id': 'did:example:d23dd687a7dc6787646f2eb98d0'}
     };
-    final vc = DIDKit.issueCredential(jsonEncode(credential), jsonEncode(options), key);
+    final vc = DIDKit.issueCredential(
+        jsonEncode(credential), jsonEncode(options), key);
 
-    final verifyOptions = {
-        'proofPurpose': 'assertionMethod'
-    };
-    final verifyResult = jsonDecode(DIDKit.verifyCredential(vc, jsonEncode(verifyOptions)));
+    final verifyOptions = {'proofPurpose': 'assertionMethod'};
+    final verifyResult =
+        jsonDecode(DIDKit.verifyCredential(vc, jsonEncode(verifyOptions)));
     expect(verifyResult['errors'], isEmpty);
   });
 
@@ -65,31 +67,29 @@ void main() {
     final did = DIDKit.keyToDID('key', key);
     final verificationMethod = DIDKit.keyToVerificationMethod('key', key);
     final options = {
-        'proofPurpose': 'authentication',
-        'verificationMethod': verificationMethod
+      'proofPurpose': 'authentication',
+      'verificationMethod': verificationMethod
     };
     final presentation = {
-        '@context': ['https://www.w3.org/2018/credentials/v1'],
-        'id': 'http://example.org/presentations/3731',
-        'type': ['VerifiablePresentation'],
-        'holder': did,
-        'verifiableCredential': {
-            '@context': 'https://www.w3.org/2018/credentials/v1',
-            'id': 'http://example.org/credentials/3731',
-            'type': ['VerifiableCredential'],
-            'issuer': 'did:example:30e07a529f32d234f6181736bd3',
-            'issuanceDate': '2020-08-19T21:41:50Z',
-            'credentialSubject': {
-                'id': 'did:example:d23dd687a7dc6787646f2eb98d0'
-            }
-        }
+      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      'id': 'http://example.org/presentations/3731',
+      'type': ['VerifiablePresentation'],
+      'holder': did,
+      'verifiableCredential': {
+        '@context': 'https://www.w3.org/2018/credentials/v1',
+        'id': 'http://example.org/credentials/3731',
+        'type': ['VerifiableCredential'],
+        'issuer': 'did:example:30e07a529f32d234f6181736bd3',
+        'issuanceDate': '2020-08-19T21:41:50Z',
+        'credentialSubject': {'id': 'did:example:d23dd687a7dc6787646f2eb98d0'}
+      }
     };
-    final vc = DIDKit.issuePresentation(jsonEncode(presentation), jsonEncode(options), key);
+    final vc = DIDKit.issuePresentation(
+        jsonEncode(presentation), jsonEncode(options), key);
 
-    final verifyOptions = {
-        'proofPurpose': 'authentication'
-    };
-    final verifyResult = jsonDecode(DIDKit.verifyPresentation(vc, jsonEncode(verifyOptions)));
+    final verifyOptions = {'proofPurpose': 'authentication'};
+    final verifyResult =
+        jsonDecode(DIDKit.verifyPresentation(vc, jsonEncode(verifyOptions)));
     expect(verifyResult['errors'], isEmpty);
   });
 
@@ -103,7 +103,8 @@ void main() {
   test('dereferenceDIDURL', () async {
     final key = DIDKit.generateEd25519Key();
     final verificationMethod = DIDKit.keyToVerificationMethod('key', key);
-    final derefResult = jsonDecode(DIDKit.dereferenceDIDURL(verificationMethod, '{}'));
+    final derefResult =
+        jsonDecode(DIDKit.dereferenceDIDURL(verificationMethod, '{}'));
     expect(derefResult, isList);
   });
 
@@ -119,10 +120,8 @@ void main() {
       'challenge': challenge
     });
     final vp = DIDKit.DIDAuth(did, proofOptions, key);
-    final verifyOptions = jsonEncode({
-      'proofPurpose': 'assertionMethod',
-      'challenge': challenge
-    });
+    final verifyOptions =
+        jsonEncode({'proofPurpose': 'assertionMethod', 'challenge': challenge});
     final verification = DIDKit.verifyPresentation(vp, verifyOptions);
     final verifyResult = jsonDecode(verification);
     expect(verifyResult['errors'], isEmpty);


### PR DESCRIPTION
Fixes spruceid/credible#51 

### Changes

1. cargo outputs a `.dylib` file on macOS hosts, I updated the Makefile to support both `dylib` and `so` files.
**I'm not a specialist on Makefiles, maybe there's a better way of accomplishing that.**

2. I've added all functions from `didkit.h` to the `didkit/lib/flutter/ios/Classes/DIDKitFlutterPlugin.m` file, cause they were being removed on release builds as they are not called anywhere.
**I manually added those functions and I think this is not the best way of doing this, maybe a better way would be some form of automation, every time the `didkit.h` changes, it automatically changes the `DIDKitFlutterPlugin.m`.**

If someone knows a better way of doing this, please suggest on the PR.