### PR TITLE
Improve JWT VC/VP support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         repository: spruceid/ssi
         path: ssi
-        ref: 164e2381eb5761b21477e60e2c6494e0f727d184
+        ref: b0900a6d0254caef457161d10653f3ac8f5138d3
         submodules: true
 
     - name: Cache Cargo registry and build artifacts
@@ -64,6 +64,36 @@ jobs:
       env:
         DID_METHOD: tz
       run: http/tests/example.sh
+
+    - name: Test CLI (JWT)
+      env:
+        PROOF_FORMAT: jwt
+      run: cli/tests/example.sh
+
+    - name: Test CLI (JWT VC in LDP VP)
+      env:
+        VC_PROOF_FORMAT: jwt
+      run: cli/tests/example.sh
+
+    - name: Test CLI (LDP VC in JWT VP)
+      env:
+        VP_PROOF_FORMAT: jwt
+      run: cli/tests/example.sh
+
+    - name: Test HTTP server (JWT)
+      env:
+        PROOF_FORMAT: jwt
+      run: http/tests/example.sh
+
+    - name: Test HTTP server (JWT VC in LDP VP)
+      env:
+        VC_PROOF_FORMAT: jwt
+      run: cli/tests/example.sh
+
+    - name: Test HTTP server (LDP VC in JWT VP)
+      env:
+        VP_PROOF_FORMAT: jwt
+      run: cli/tests/example.sh
 
     - name: Checkout vc-http-api v0.0.1
       uses: actions/checkout@v2

--- a/cli/tests/cli.rs
+++ b/cli/tests/cli.rs
@@ -5,7 +5,7 @@ use std::process::{Command, Stdio};
 static BIN: &str = env!("CARGO_BIN_EXE_didkit");
 
 const DID_KEY_K256: &'static str = "did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme";
-const DID_KEY_P256: &'static str = "did:key:zrurwcJZss4ruepVNu1H3xmSirvNbzgBk9qrCktB6kaewXnJAhYWwtP3bxACqBpzjZdN7TyHNzzGGSSH5qvZsSDir9z";
+const DID_KEY_P256: &'static str = "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169";
 
 #[test]
 fn generate_key() {

--- a/http/tests/main.rs
+++ b/http/tests/main.rs
@@ -18,7 +18,7 @@ const DID_KEY: &'static str = "did:key:z6MkiVpwA241guqtKWAkohHpcAry7S94QQb6ukW3G
 const VERIFICATION_METHOD: &'static str = "did:key:z6MkiVpwA241guqtKWAkohHpcAry7S94QQb6ukW3GcCsugbK#z6MkiVpwA241guqtKWAkohHpcAry7S94QQb6ukW3GcCsugbK";
 
 const DID_KEY_K256: &'static str = "did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme";
-const DID_KEY_P256: &'static str = "did:key:zrurwcJZss4ruepVNu1H3xmSirvNbzgBk9qrCktB6kaewXnJAhYWwtP3bxACqBpzjZdN7TyHNzzGGSSH5qvZsSDir9z";
+const DID_KEY_P256: &'static str = "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169";
 
 const ISSUE_CRED_REQ: &str = r#"{
     "credential": {

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -36,6 +36,7 @@ did-pkh = { version = "0.0.1", path = "../../ssi/did-pkh" }
 did-sol = { version = "0.0.1", path = "../../ssi/did-sol" }
 did-web = { version = "0.1", path = "../../ssi/did-web" }
 did-onion = { version = "0.1", path = "../../ssi/did-onion" }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 jni = "0.17"
 lazy_static = "1.4"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -24,7 +24,7 @@ ring = ["ssi/ring"]
 wasm = []
 http-did = ["ssi/http-did"]
 secp256k1 = ["ssi/libsecp256k1", "did-tz/secp256k1", "did-method-key/secp256k1"]
-p256 = ["ssi/p256", "did-tz/p256", "did-method-key/p256"]
+p256 = ["ssi/secp256r1", "did-tz/p256", "did-method-key/secp256r1"]
 
 [dependencies]
 didkit-cbindings = { path = "cbindings/" }

--- a/lib/java/test/com/spruceid/DIDKitTest.java
+++ b/lib/java/test/com/spruceid/DIDKitTest.java
@@ -24,7 +24,7 @@ class DIDKitTest {
         }
         assert threw;
 
-        // Issue Credential
+        // Issue Credential (LDP)
         String credential = "{"
             + "   \"@context\": \"https://www.w3.org/2018/credentials/v1\","
             + "   \"id\": \"http://example.org/credentials/3731\","
@@ -40,15 +40,30 @@ class DIDKitTest {
             + "  \"verificationMethod\": \"" + verificationMethod + "\""
             + "}";
         String vc = DIDKit.issueCredential(credential, vcOptions, jwk);
+        // Issue Credential (JWT)
+        String vcOptionsJwt = "{"
+            + "  \"proofPurpose\": \"assertionMethod\","
+            + "  \"proofFormat\": \"jwt\","
+            + "  \"verificationMethod\": \"" + verificationMethod + "\""
+            + "}";
+        String vcJwt = DIDKit.issueCredential(credential, vcOptionsJwt, jwk);
 
-        // Verify Credential
+        // Verify Credential (LDP)
         String vcVerifyOptions = "{"
             + "  \"proofPurpose\": \"assertionMethod\""
             + "}";
         String vcResult = DIDKit.verifyCredential(vc, vcVerifyOptions);
         assert vcResult.contains("\"errors\":[]");
 
-        // Issue Presentation
+        // Verify Credential (JWT)
+        vcVerifyOptions = "{"
+            + "  \"proofPurpose\": \"assertionMethod\","
+            + "  \"proofFormat\": \"jwt\""
+            + "}";
+        vcResult = DIDKit.verifyCredential(vcJwt, vcVerifyOptions);
+        assert vcResult.contains("\"errors\":[]");
+
+        // Issue Presentation (LDP)
         String presentation = "{"
             + "   \"@context\": [\"https://www.w3.org/2018/credentials/v1\"],"
             + "   \"id\": \"http://example.org/presentations/3731\","
@@ -62,11 +77,27 @@ class DIDKitTest {
             + "}";
         String vp = DIDKit.issuePresentation(presentation, vpOptions, jwk);
 
-        // Verify Presentation
+        // Issue Presentation (JWT)
+        String vpOptionsJwt = "{"
+            + "  \"proofPurpose\": \"authentication\","
+            + "  \"proofFormat\": \"jwt\","
+            + "  \"verificationMethod\": \"" + verificationMethod + "\""
+            + "}";
+        String vpJwt = DIDKit.issuePresentation(presentation, vpOptions, jwk);
+
+        // Verify Presentation (LDP)
         String vpVerifyOptions = "{"
             + "  \"proofPurpose\": \"authentication\""
             + "}";
         String vpResult = DIDKit.verifyPresentation(vp, vpVerifyOptions);
+        assert vpResult.contains("\"errors\":[]");
+
+        // Verify Presentation (JWT)
+        vpVerifyOptions = "{"
+            + "  \"proofPurpose\": \"authentication\","
+            + "  \"proofFormat\": \"jwt\""
+            + "}";
+        vpResult = DIDKit.verifyPresentation(vpJwt, vpVerifyOptions);
         assert vpResult.contains("\"errors\":[]");
 
         // Resolve DID
@@ -77,7 +108,7 @@ class DIDKitTest {
         String dereferencingResult = DIDKit.dereferenceDIDURL(verificationMethod, "{}");
         assert dereferencingResult.startsWith("[{");
 
-        // Create a DIDAuth VP
+        // Create a DIDAuth VP (LDP)
         vpOptions = "{"
             + "  \"proofPurpose\": \"authentication\","
             + "  \"domain\": \"example.org\","
@@ -85,12 +116,30 @@ class DIDKitTest {
             + "}";
         vp = DIDKit.DIDAuth(did, vpOptions, jwk);
 
-        // Verify Presentation
+        // Create a DIDAuth VP (JWT)
+        vpOptions = "{"
+            + "  \"proofPurpose\": \"authentication\","
+            + "  \"proofFormat\": \"jwt\","
+            + "  \"domain\": \"example.org\","
+            + "  \"verificationMethod\": \"" + verificationMethod + "\""
+            + "}";
+        vpJwt = DIDKit.DIDAuth(did, vpOptions, jwk);
+
+        // Verify DIDAuth VP (LDP)
         vpVerifyOptions = "{"
             + "  \"domain\": \"example.org\","
             + "  \"proofPurpose\": \"authentication\""
             + "}";
         vpResult = DIDKit.verifyPresentation(vp, vpVerifyOptions);
+        assert vpResult.contains("\"errors\":[]");
+
+        // Verify DIDAuth VP (JWT)
+        vpVerifyOptions = "{"
+            + "  \"domain\": \"example.org\","
+            + "  \"proofPurpose\": \"authentication\","
+            + "  \"proofFormat\": \"jwt\""
+            + "}";
+        vpResult = DIDKit.verifyPresentation(vpJwt, vpVerifyOptions);
         assert vpResult.contains("\"errors\":[]");
     }
 }

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -27,6 +27,7 @@ pub enum Error {
     UnableToGenerateDID,
     UnknownDIDMethod,
     UnableToGetVerificationMethod,
+    UnknownProofFormat(String),
 
     #[doc(hidden)]
     __Nonexhaustive,
@@ -89,6 +90,7 @@ impl fmt::Display for Error {
             Error::UnableToGenerateDID => write!(f, "Unable to generate DID"),
             Error::UnknownDIDMethod => write!(f, "Unknown DID method"),
             Error::UnableToGetVerificationMethod => write!(f, "Unable to get verification method"),
+            Error::UnknownProofFormat(format) => write!(f, "Unknown proof format: {}", format),
             _ => unreachable!(),
         }
     }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -25,7 +25,75 @@ pub use ssi::ldp::resolve_key;
 pub use ssi::ldp::ProofPreparation;
 pub use ssi::vc::get_verification_method;
 pub use ssi::vc::Credential as VerifiableCredential;
+pub use ssi::vc::CredentialOrJWT;
 pub use ssi::vc::LinkedDataProofOptions;
 pub use ssi::vc::Presentation as VerifiablePresentation;
 pub use ssi::vc::ProofPurpose;
 pub use ssi::vc::VerificationResult;
+
+use core::str::FromStr;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[non_exhaustive]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct JWTOrLDPOptions {
+    /// Linked data proof options from vc-http-api
+    #[serde(flatten)]
+    pub ldp_options: LinkedDataProofOptions,
+    /// Proof format (not standard in vc-http-api)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proof_format: Option<ProofFormat>,
+}
+
+impl JWTOrLDPOptions {
+    pub fn default_for_vp() -> Self {
+        Self {
+            ldp_options: LinkedDataProofOptions {
+                proof_purpose: Some(ProofPurpose::Authentication),
+                ..Default::default()
+            },
+            proof_format: None,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum ProofFormat {
+    /// <https://www.w3.org/TR/vc-data-model/#linked-data-proofs>
+    #[serde(rename = "ldp")]
+    LDP,
+    /// <https://www.w3.org/TR/vc-data-model/#json-web-token>
+    #[serde(rename = "jwt")]
+    JWT,
+}
+// ProofFormat implements Display and FromStr for structopt. This should be kept in sync with the
+// serde (de)serialization (rename = ...)
+
+impl Default for ProofFormat {
+    fn default() -> Self {
+        Self::LDP
+    }
+}
+
+impl std::fmt::Display for ProofFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::LDP => write!(f, "ldp"),
+            Self::JWT => write!(f, "jwt"),
+        }
+    }
+}
+
+impl FromStr for ProofFormat {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match &s[..] {
+            "ldp" => Ok(Self::LDP),
+            "jwt" => Ok(Self::JWT),
+            _ => Err(format!("Unexpected proof format: {}", s))?,
+        }
+    }
+}

--- a/lib/web/loader/wasm/test/index.test.js
+++ b/lib/web/loader/wasm/test/index.test.js
@@ -1,9 +1,9 @@
-const test = (title, fn) => {
+const test = async (title, fn) => {
   try {
-    fn();
+    await fn();
     console.log(`[    ok: ${title}]`);
   } catch (e) {
-    console.error(`[fail: ${title}]`, e.stack);
+    console.error(`[fail: ${title}]`, e);
   }
 };
 
@@ -83,7 +83,7 @@ DIDKitLoader.loadDIDKit("/didkit_wasm_bg.wasm").then(
       }
     });
 
-    test("should verify issued credential", async () => {
+    test("should verify issued credential (LDP)", async () => {
       const credential = await issueCredential(
         JSON.stringify({
           "@context": "https://www.w3.org/2018/credentials/v1",
@@ -114,6 +114,39 @@ DIDKitLoader.loadDIDKit("/didkit_wasm_bg.wasm").then(
       if (verify.errors.length > 0) throw verify.errors;
     });
 
+    test("should verify issued credential (JWT)", async () => {
+      const credential = await issueCredential(
+        JSON.stringify({
+          "@context": "https://www.w3.org/2018/credentials/v1",
+          id: "http://example.org/credentials/3731",
+          type: ["VerifiableCredential"],
+          issuer: did,
+          issuanceDate: "2020-08-19T21:41:50Z",
+          credentialSubject: {
+            id: other.did,
+          },
+        }),
+        JSON.stringify({
+          proofPurpose: "assertionMethod",
+          proofFormat: "jwt",
+          verificationMethod: verificationMethod,
+        }),
+        keyStr
+      );
+
+      const verifyStr = await verifyCredential(
+        credential,
+        JSON.stringify({
+          proofPurpose: "assertionMethod",
+          proofFormat: "jwt",
+        })
+      );
+
+      const verify = JSON.parse(verifyStr);
+
+      if (verify.errors.length > 0) throw verify.errors;
+    });
+
     test("should fail if parameters are empty objects", async () => {
       try {
         await issuePresentation(emptyObj, emptyObj, emptyObj);
@@ -123,7 +156,7 @@ DIDKitLoader.loadDIDKit("/didkit_wasm_bg.wasm").then(
       }
     });
 
-    test("should verify issued presentation", async () => {
+    test("should verify issued presentation (LDP VC in LDP VP)", async () => {
       const credential = JSON.parse(
         await issueCredential(
           JSON.stringify({
@@ -171,7 +204,153 @@ DIDKitLoader.loadDIDKit("/didkit_wasm_bg.wasm").then(
       if (verify.errors.length > 0) throw verify.errors;
     });
 
-    test("should issue and verify DIDAuth presentation", async () => {
+    test("should verify issued presentation (LDP VC in JWT VP)", async () => {
+      const credential = JSON.parse(
+        await issueCredential(
+          JSON.stringify({
+            "@context": "https://www.w3.org/2018/credentials/v1",
+            id: "http://example.org/credentials/3731",
+            type: ["VerifiableCredential"],
+            issuer: did,
+            issuanceDate: "2020-08-19T21:41:50Z",
+            credentialSubject: {
+              id: other.did,
+            },
+          }),
+          JSON.stringify({
+            proofPurpose: "assertionMethod",
+            verificationMethod: verificationMethod,
+          }),
+          keyStr
+        )
+      );
+
+      const presentation = await issuePresentation(
+        JSON.stringify({
+          "@context": ["https://www.w3.org/2018/credentials/v1"],
+          id: "http://example.org/presentations/3731",
+          type: ["VerifiablePresentation"],
+          holder: other.did,
+          verifiableCredential: credential,
+        }),
+        JSON.stringify({
+          proofPurpose: "authentication",
+          proofFormat: "jwt",
+          verificationMethod: other.verificationMethod,
+        }),
+        other.keyStr
+      );
+
+      const verifyStr = await verifyPresentation(
+        presentation,
+        JSON.stringify({
+          proofPurpose: "authentication",
+          proofFormat: "jwt",
+        })
+      );
+
+      const verify = JSON.parse(verifyStr);
+
+      if (verify.errors.length > 0) throw verify.errors;
+    });
+
+    test("should verify issued presentation (JWT VC in LDP VP)", async () => {
+      const credential = await issueCredential(
+        JSON.stringify({
+          "@context": "https://www.w3.org/2018/credentials/v1",
+          id: "http://example.org/credentials/3731",
+          type: ["VerifiableCredential"],
+          issuer: did,
+          issuanceDate: "2021-06-09T18:41:27Z",
+          credentialSubject: {
+            id: other.did,
+          },
+        }),
+        JSON.stringify({
+          proofPurpose: "assertionMethod",
+          proofFormat: "jwt",
+          verificationMethod: verificationMethod,
+        }),
+        keyStr
+      );
+
+      const presentation = await issuePresentation(
+        JSON.stringify({
+          "@context": ["https://www.w3.org/2018/credentials/v1"],
+          id: "http://example.org/presentations/3731",
+          type: ["VerifiablePresentation"],
+          holder: other.did,
+          verifiableCredential: credential,
+        }),
+        JSON.stringify({
+          proofPurpose: "authentication",
+          verificationMethod: other.verificationMethod,
+        }),
+        other.keyStr
+      );
+
+      const verifyStr = await verifyPresentation(
+        presentation,
+        JSON.stringify({
+          proofPurpose: "authentication",
+        })
+      );
+
+      const verify = JSON.parse(verifyStr);
+
+      if (verify.errors.length > 0) throw verify.errors;
+    });
+
+    test("should verify issued presentation (JWT VC in JWT VP)", async () => {
+      const credential = await issueCredential(
+        JSON.stringify({
+          "@context": "https://www.w3.org/2018/credentials/v1",
+          id: "http://example.org/credentials/3731",
+          type: ["VerifiableCredential"],
+          issuer: did,
+          issuanceDate: "2021-06-09T18:41:27Z",
+          credentialSubject: {
+            id: other.did,
+          },
+        }),
+        JSON.stringify({
+          proofPurpose: "assertionMethod",
+          proofFormat: "jwt",
+          verificationMethod: verificationMethod,
+        }),
+        keyStr
+      );
+
+      const presentation = await issuePresentation(
+        JSON.stringify({
+          "@context": ["https://www.w3.org/2018/credentials/v1"],
+          id: "http://example.org/presentations/3731",
+          type: ["VerifiablePresentation"],
+          holder: other.did,
+          verifiableCredential: credential,
+        }),
+        JSON.stringify({
+          proofPurpose: "authentication",
+          proofFormat: "jwt",
+          verificationMethod: other.verificationMethod,
+        }),
+        other.keyStr
+      );
+
+      const verifyStr = await verifyPresentation(
+        presentation,
+        JSON.stringify({
+          proofPurpose: "authentication",
+          proofFormat: "jwt",
+        })
+      );
+
+      const verify = JSON.parse(verifyStr);
+
+      if (verify.errors.length > 0) throw verify.errors;
+    });
+
+    test("should issue and verify DIDAuth presentation (LDP)", async () => {
       const challenge = Math.random().toString(16).substr(2);
       const verifiablePresentation = JSON.parse(
         await DIDAuth(
@@ -189,6 +368,33 @@ DIDKitLoader.loadDIDKit("/didkit_wasm_bg.wasm").then(
         JSON.stringify(verifiablePresentation),
         JSON.stringify({
           proofPurpose: "authentication",
+          challenge,
+        })
+      );
+
+      const verify = JSON.parse(verifyStr);
+
+      if (verify.errors.length > 0) throw verify.errors;
+    });
+
+    test("should issue and verify DIDAuth presentation (JWT)", async () => {
+      const challenge = Math.random().toString(16).substr(2);
+      const verifiablePresentation = await DIDAuth(
+        did,
+        JSON.stringify({
+          proofPurpose: "authentication",
+          proofFormat: "jwt",
+          challenge,
+          verificationMethod,
+        }),
+        keyStr
+      );
+
+      const verifyStr = await verifyPresentation(
+        verifiablePresentation,
+        JSON.stringify({
+          proofPurpose: "authentication",
+          proofFormat: "jwt",
           challenge,
         })
       );


### PR DESCRIPTION
Fix #149. This is to implement support for JWT VCs and VPs using the existing API.

Conflicts with #158. Depends on https://github.com/spruceid/ssi/pull/201

- [x] Create a DIDAuth VP on CLI. Confirm verification with another JWT implementation:
  - [x] RS256: [jwt.io](https://jwt.io/#debugger-io?token=eyJhbGciOiJSUzI1NiIsImtpZCI6InJzYTIwNDgtMjAyMC0wOC0yNSJ9.eyJpc3MiOiJkaWQ6ZXhhbXBsZTpmb28iLCJ2cCI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjoiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJ9fQ.MqNO2aAfdxP7tFBaEKPHJc4vGEDt_aOZ8o1n5tvcol9NZMozyu7OHltJmEHXRBIVU3LRObm-nOorPshLPrz3etSPDkbzl0zkn8KMq__rq5tYKMQJ__8DXzz7T2F_eGJDLWJUqKHP_JRzZtSSKBb6fCDu-_nKxK-EjuXGSyYe05AteEczRSATjF89ycsGp1i74neZrN0tey7GxPI8d6X_2FVPVvH72OGJ50zmMoV1aHItzOOttTwDT8qdLy6rw9pPZqI1Y6JOU-2PVZMxgNFJZ35l0cPaUSZ2sfQzaP5UL9Ufmf1BZZ-lzFWzLa8fLSK7JbOFWP7arbaqqPJ9qFgLPA&publicKey=-----BEGIN%20PUBLIC%20KEY-----%0AMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsbX82NTV6IylxCh7MfV4%0AhlyvaniCajuP97GyOqSvTmoEdBOflFvZ06kR%2F9D6ctt45Fk6hskfnag2GG69NALV%0AH2o4RCR6tQiLRpKcMRtDYE%2FthEmfBvDzm%2FVVkOIYfxu%2BIpuo9J%2FS5XDNDjczx2v%2B%0A3oDh5%2BCIHkU46hvFeCvpUS%2BL8TJSbgX0kjVk%2Fm4eIb9wh63rtmD6Uz%2FKBtCo5mmR%0A4TEtcLZKYdqMp3wCjN%2BTlgHiz%2F4oVXWbHUefCEe8rFnX1iQnpDHU49%2FSaXQoud1j%0ACaexFn25n%2BAa8f8bc5Vm%2B5SeRwidHa6ErvEhTvf1dz6GoNPp2iRvm%2BwJ1gxwWJEY%0APQIDAQAB%0A-----END%20PUBLIC%20KEY-----%0A) `didkit did-auth -k ../ssi/tests/rsa2048-2020-08-25.json --holder 'did:example:foo' -f jwt`
  - [x] ES256: [jwt.io](https://jwt.io/#debugger-io?token=eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJkaWQ6ZXhhbXBsZTpmb28iLCJ2cCI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjoiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJ9fQ.rJzO6MmTNS8Tn-L3baIf9_2Jr9OoK8E06MxJtofz8xMUGSom6eRUmWGZ7oQVjgP3HogOD80miTvuvKTWa54Nvw&publicKey=-----BEGIN%20PUBLIC%20KEY-----%0AMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOnI8cxizlWZUBw5icIHEUn5EVMpc%0Az4bNr%2F%2FHnrmYGrEgHc0lCVf2sK7TLIBhKbST5WTU2U2SQRxFRkvBkee4Zw%3D%3D%0A-----END%20PUBLIC%20KEY-----%0A) `didkit did-auth -k ../ssi/tests/secp256r1-2021-03-18.json --holder 'did:example:foo' -f jwt`
  - [x] ES256K: [jose](https://github.com/panva/jose/blob) - [index.js.txt](https://github.com/spruceid/didkit/files/6703918/index.js.txt)
- [x] Update CLI issuance subcommands to allow JWT.
  - [x] VC
  - [x] VP
- [x] Update CLI verification subcommands to allow JWT.
  - [x] VC
  - [x] VP
- [x] Test CLI: enable using JWT in `cli/tests/example.sh` - or make a separate example/demo script.
- [x] Test in HTTP
- [ ] Test/update FFI
  - [x] C (ABI also used by Python and Dart/Flutter)
  - [x] JNI
  - [x] Node.js
  - [ ] WASM
    - [x] issue/verify VC/VP
    - [ ] prepare/complete issue VC/VP