### PR TITLE
Use Default with LinkedDataProofOptions

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -188,6 +188,7 @@ impl From<ProofOptions> for LinkedDataProofOptions {
             challenge: options.challenge,
             domain: options.domain,
             checks: None,
+            ..Default::default()
         }
     }
 }


### PR DESCRIPTION
This change allows the LinkedDataProofOptions struct to gain more properties, as happened in https://github.com/spruceid/ssi/pull/213.