### PR TITLE
Set iOS deployment target to 11.0

### DIFF
--- a/lib/flutter/ios/didkit.podspec
+++ b/lib/flutter/ios/didkit.podspec
@@ -18,7 +18,7 @@ DIDKit Flutter plugin - iOS implementation
   s.static_framework = true
   s.vendored_libraries = "**/*.a"
   s.dependency 'Flutter'
-  s.platform = :ios, '8.0'
+  s.platform = :ios, '11.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
### Changes
* Set the iOS deployment target of the flutter lib to 11.0

### Why
Rust doesn't generate a library for `armv7-apple-ios` target, that is needed for iOS version less than 11 (older devices runs armv7 architecture), so we can bump the minimum version of the flutter lib to iOS 11 (the first version that doesn't support armv7)