### PR TITLE
Add to-rdf-urdna2015 subcommand

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -550,7 +550,6 @@ fn main() {
             more_context_json,
         } => {
             use ssi::jsonld::{json_to_dataset, JsonLdOptions, StaticLoader};
-            use std::io::Read;
             let mut loader = StaticLoader;
             let mut reader = BufReader::new(stdin());
             let mut json = String::new();

--- a/cli/tests/.gitignore
+++ b/cli/tests/.gitignore
@@ -6,6 +6,7 @@ presentation-signed.jsonld
 presentation-unsigned.jsonld
 presentation-verify-result.json
 auth-verify-result.json
-auth.jsonld
+auth
+auth.nq
 did.json
 vm.json

--- a/cli/tests/example.sh
+++ b/cli/tests/example.sh
@@ -230,5 +230,18 @@ then
 fi
 echo 'Verified DIDAuth verifiable presentation:'
 print_json auth-verify-result.json
+echo
+
+# Convert VP to Canonicalized RDF
+if [ "$vp_proof_format" = ldp ]; then
+	if ! didkit to-rdf-urdna2015 < auth > auth.nq
+	then
+		echo 'Unable to convert/canonicalize document:' >&2
+		exit 1
+	fi
+	echo 'Converted verifiable presentation to canonicalized N-Quads:'
+	cat auth.nq
+fi
+echo
 
 echo Done


### PR DESCRIPTION
This adds a CLI subcommand for converting JSON-LD to canonicalized RDF, to address #163.

1. Perform context expansion of JSON-LD document.
2. Deserialize JSON-LD document to RDF dataset.
3. Canonicalize dataset using [URDNA2015](https://json-ld.github.io/rdf-dataset-canonicalization/spec/).
4. Serialize dataset in [N-Quads](https://www.w3.org/TR/n-quads/) format.

This exposes the functionality used internally by many [linked data signature](https://w3c-ccg.github.io/ld-proofs/) [suites](https://w3c-ccg.github.io/ld-cryptosuite-registry/). It can be useful for inspecting the data contents of a verifiable credential or presentation, [linked data authorization capability](https://w3c-ccg.github.io/zcap-ld/), or other linked data document.

Another use for this sub-command is to construct linked data proof signing payloads for external signing. Note that for such signing payloads, the proof object and linked data document without proof object must be canonicalized separately, according to the linked data proof [Create Verify Hash Algorithm](https://w3c-ccg.github.io/ld-proofs/#create-verify-hash-algorithm). Furthermore, the proof object needs context defined for its terms which are otherwise defined in the document's parent context. Context such as that can be passed to this subcommand using the `-c, --expand-context` or `-C, --more-context-json` options. `-c` takes a URI (e.g. for the w3c-ccg security context, or vc-data-model base context, or a signature suite context) and corresponds to the [JSON-LD `expandContext` option](https://www.w3.org/TR/json-ld11-api/#dom-jsonldoptions-expandcontext), while `-C` takes a JSON array of values to insert into the `@context` property of the payload (creating it if needed).

### Usage
```
$ didkit to-rdf-urdna2015 --help
didkit-to-rdf-urdna2015 0.1.0
Convert JSON-LD to URDNA2015-canonicalized RDF N-Quads

USAGE:
    didkit to-rdf-urdna2015 [OPTIONS]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -b, --base <base>                              Base IRI
    -c, --expand-context <expand-context>          IRI for expandContext option
    -C, --more-context-json <more-context-json>    Additional values for JSON-LD @context property
```

### Example
```
$ didkit to-rdf-urdna2015 < cli/tests/auth.jsonld
_:c14n0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiablePresentation> .
_:c14n0 <https://w3id.org/security#proof> _:c14n1 .
_:c14n0 <https://www.w3.org/2018/credentials#holder> <did:key:z6MkvYdEj32i7fTvLqg2uj26AJPGqu4qpX5t7ZSzwGJcSyQ5> .
_:c14n2 <http://purl.org/dc/terms/created> "2021-06-07T14:12:00.349Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> _:c14n1 .
_:c14n2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Ed25519Signature2018> _:c14n1 .
_:c14n2 <https://w3id.org/security#challenge> "0.726156" _:c14n1 .
_:c14n2 <https://w3id.org/security#jws> "eyJhbGciOiJFZERTQSIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..5zelz6ht6Zia4enNwv_rmJqI6xyQo247YQ7YE_Rx2xMhjwohv7AUrnOchAW23buyrMUQDIqWS36bxVyhYUC_Dw" _:c14n1 .
_:c14n2 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#authenticationMethod> _:c14n1 .
_:c14n2 <https://w3id.org/security#verificationMethod> <did:key:z6MkvYdEj32i7fTvLqg2uj26AJPGqu4qpX5t7ZSzwGJcSyQ5#z6MkvYdEj32i7fTvLqg2uj26AJPGqu4qpX5t7ZSzwGJcSyQ5> _:c14n1 .
```
Canonicalizing proof object only:
```
$ jq .proof cli/tests/auth.jsonld | didkit to-rdf-urdna2015 -c https://www.w3.org/2018/credentials/v1
_:c14n0 <http://purl.org/dc/terms/created> "2021-06-07T14:12:00.349Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
_:c14n0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Ed25519Signature2018> .
_:c14n0 <https://w3id.org/security#challenge> "0.726156" .
_:c14n0 <https://w3id.org/security#jws> "eyJhbGciOiJFZERTQSIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..5zelz6ht6Zia4enNwv_rmJqI6xyQo247YQ7YE_Rx2xMhjwohv7AUrnOchAW23buyrMUQDIqWS36bxVyhYUC_Dw" .
_:c14n0 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#authenticationMethod> .
_:c14n0 <https://w3id.org/security#verificationMethod> <did:key:z6MkvYdEj32i7fTvLqg2uj26AJPGqu4qpX5t7ZSzwGJcSyQ5#z6MkvYdEj32i7fTvLqg2uj26AJPGqu4qpX5t7ZSzwGJcSyQ5> .
```
