### PR TITLE
Add binary signing example

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,9 @@ jobs:
         VP_PROOF_FORMAT: jwt
       run: cli/tests/example.sh
 
+    - name: Test binary-signing verify example
+      run: examples/binary-signing/index.sh verify examples/binary-signing/hello.txt examples/binary-signing/hello-vc.jsonld
+
     - name: Checkout vc-http-api v0.0.1
       uses: actions/checkout@v2
       with:

--- a/examples/binary-signing/README.md
+++ b/examples/binary-signing/README.md
@@ -1,0 +1,69 @@
+# Binary signing example
+
+Use Verifiable Credentials and DIDKit to sign and verify binary files.
+
+## Credential Format
+
+The [credential subject][] represents a binary file, and is expected to have a `digest` (`https://w3id.org/security#digest`) property, and a `contentSize` (https://schema.org/contentSize) property.  The `contentSize` property encodes the file size in bytes, as a string with "B" suffix. The `digest` property contains an object of type `Digest` (https://w3id.org/security#Digest), which has properties `digestAlgorithm` (https://w3id.org/security#digestAlgorithm) and `digestValue` (https://w3id.org/security#digestValue). The currently supported digest algorithm is SHA-256 (`sha256`; http://www.w3.org/2001/04/xmlenc#sha256). The digest value is encoded as a lowercase hexadecimal string. The credential subject may also encode the file's content-type in the `encodingFormat` (https://schema.org/encodingFormat) property, for informative purposes.
+
+See [hello-vc.jsonld](./hello-vc.jsonld) in this directory for an example verifiable credential over file [hello.txt](./hello.txt).
+
+## Program
+
+The example program in this directory is a shell script using DIDKit to issue or verify a binary signing verifiable credential. The script uses AWK to extract and verify the [claims][] encoded in the verifiable credential.
+
+### Sign
+
+To issue a verifiable credential to sign over a file, run the `sign` subcommand of the `index.sh` program in this directory, passing the filename to sign over, your DID to issue the credential, verification method id for signing, and JWK filename. 
+
+#### SSH Agent
+
+By default, signing uses DIDKit's ssh-agent functionality. The JWK file passed as an argument should contain the public key for the verification method. `ssh-agent` must be running in the current shell. To start a new shell with ssh-agent, run `ssh-agent bash`. Then run `ssh-add` to unlock your SSH public keys and add them to ssh-agent - or use `ssh-add` to unlock specific keys. For more info, see the manual pges for `ssh-agent(1)` and `ssh-add(1)`. To not use `ssh-agent`, set environmental variable `USE_SSH_AGENT=no` before running the sign command, and pass your private key for signing as the JWK argument.
+
+#### Key selection
+
+If you are using signing with ssh-agent, convert your SSH public key to a JWK public key:
+```
+didkit ssh-pk-to-jwk "$(cat ~/.ssh/id_ed25519.pub)" > sshpk.jwk
+jwk=sshpk.jwk
+```
+If you are signing without ssh-agent and want to use a new keypair, generate one with DIDKit:
+```
+didkit generate-ed25519-key > edsk.jwk
+jwk=edsk.jwk
+export USE_SSH_AGENT=no
+```
+
+Otherwise, if you have a JWK already, find it:
+```
+jwk=key.jwk
+```
+
+Construct the DID and verification method id. If issuing using `did:key`:
+```
+did=$(didkit key-to-did key -k $jwk)
+vm=$(didkit key-to-verification-method key -k $jwk)
+```
+
+If using `did:web` or `did:webkey`, you can use DIDKit to resolve the DID and manually find the verification method ID to use. It should match the JWK that you pass to the sign command below.
+```
+did='did:web:example.org'
+didkit did-resolve "$did"
+...
+vm='did:web:example.org#key1'
+```
+
+Perform signing, saving the resulting verifiable credential to a file:
+```
+./index.sh sign hello.txt "$did" "$vm" "$jwk" | jq > hello-vc.jsonld
+```
+
+#### Verify
+
+Run the verify subcommand, passing the file and the verifiable credential. The command should return with a zero exit status on successful verification.
+```
+./index.sh verify hello.txt hello-vc.jsonld
+```
+
+[credential subject]: https://www.w3.org/TR/vc-data-model/#credential-subject
+[claims]: https://www.w3.org/TR/vc-data-model/#claims

--- a/examples/binary-signing/hello-vc.jsonld
+++ b/examples/binary-signing/hello-vc.jsonld
@@ -1,0 +1,44 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    {
+      "digest": "https://w3id.org/security#digest",
+      "contentSize": "https://schema.org/contentSize",
+      "digestAlgorithm": {
+        "@context": {
+          "@protected": true,
+          "@version": 1.1,
+          "sha256": "http://www.w3.org/2001/04/xmlenc#sha256"
+        },
+        "@id": "https://w3id.org/security#digestAlgorithm",
+        "@type": "@vocab"
+      },
+      "@version": 1.1,
+      "encodingFormat": "https://schema.org/encodingFormat",
+      "digestValue": "https://w3id.org/security#digestValue",
+      "@protected": true,
+      "Digest": "https://w3id.org/security#Digest"
+    }
+  ],
+  "type": [
+    "VerifiableCredential"
+  ],
+  "credentialSubject": {
+    "encodingFormat": "text/plain",
+    "contentSize": "14B",
+    "digest": {
+      "@type": "Digest",
+      "digestAlgorithm": "sha256",
+      "digestValue": "d9014c4624844aa5bac314773d6b689ad467fa4e1d1a50a1b8a99d5a95f72ff5"
+    }
+  },
+  "issuer": "did:key:z6MkvqQkPMiQ2vrH6BswRJc6cF5yH6iSk94STxhMZzmBJTon",
+  "issuanceDate": "2021-07-07T17:43:09Z",
+  "proof": {
+    "type": "Ed25519Signature2018",
+    "proofPurpose": "assertionMethod",
+    "verificationMethod": "did:key:z6MkvqQkPMiQ2vrH6BswRJc6cF5yH6iSk94STxhMZzmBJTon#z6MkvqQkPMiQ2vrH6BswRJc6cF5yH6iSk94STxhMZzmBJTon",
+    "created": "2021-07-07T17:43:09.300Z",
+    "jws": "eyJhbGciOiJFZERTQSIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..Tk0RMtEQIS3ezTAyPz2gfU_iVm22_1uJ60GIIm6C0CHsUx1-08RIpeeo7vnvNGo8OZHHRBM2oSIMB_wYVPmMBw"
+  }
+}

--- a/examples/binary-signing/hello.txt
+++ b/examples/binary-signing/hello.txt
@@ -1,0 +1,1 @@
+Hello, world!

--- a/examples/binary-signing/index.sh
+++ b/examples/binary-signing/index.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+set -e
+prog=${0##*/}
+dir=${0%/*}
+export PATH="$dir/../../target/debug:$PATH"
+
+err() {
+	code=$1; shift
+	printf "$@"
+	exit $code
+}
+
+sign() {
+	file=${1?file}
+	did=${2?did}
+	vm=${3?verification method}
+	pk=${4?public_key.jwk}
+	content_type=$(file -b --mime-type "$file")
+	size=$(wc -c < "$file")
+	sha256sum=$(shasum -a 256 "$file" | cut -f1 -d ' ')
+	date=$(date -u +%FT%TZ)
+	case "$USE_SSH_AGENT" in
+		''|[yY]*) ssh_agent_arg=-S;;
+		[nN]*) ssh_agent_arg=;;
+		*) err 1 "%s: Unknown option for \$USE_SSH_AGENT: '%s'\n" "$prog" "$USE_SSH_AGENT";; 
+	esac
+	didkit vc-issue-credential \
+		-p assertionMethod \
+		-k "$pk" -v "$vm" \
+		$ssh_agent_arg \
+<<EOF
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    {
+      "@version": 1.1,
+      "@protected": true,
+      "contentSize": "https://schema.org/contentSize",
+      "encodingFormat": "https://schema.org/encodingFormat",
+      "digest": "https://w3id.org/security#digest",
+      "Digest": "https://w3id.org/security#Digest",
+      "digestAlgorithm": {
+        "@id": "https://w3id.org/security#digestAlgorithm",
+        "@type": "@vocab",
+        "@context": {
+          "@version": 1.1,
+          "@protected": true,
+          "sha256": "http://www.w3.org/2001/04/xmlenc#sha256"
+        }
+      },
+      "digestValue": "https://w3id.org/security#digestValue"
+    }
+  ],
+  "type": [
+    "VerifiableCredential"
+  ],
+  "issuer": "$did",
+  "issuanceDate": "$date",
+  "credentialSubject": {
+    "contentSize": "${size}B",
+    "encodingFormat": "$content_type",
+    "digest": {
+      "@type": "Digest",
+      "digestAlgorithm": "sha256",
+      "digestValue": "$sha256sum"
+    }
+  }
+}
+EOF
+}
+
+verify() {
+	file=${1?file}
+	vc=${2?verifiable credential}
+	didkit vc-verify-credential -p assertionMethod < "$vc"
+	echo
+	didkit to-rdf-urdna2015 < "$vc" | awk \
+	  -f $dir/rdf.awk \
+	  -f $dir/verify.awk \
+	  -v file=$file
+}
+
+usage() {
+	cat <<-EOF
+	Usage: $prog <command>...
+	Commands:
+	  sign <file> <did> <vm> <pk_jwk> > <vc_file>
+	  verify <file> <vc_file>
+	EOF
+}
+
+if [ "$#" -eq 0 ]; then
+	usage
+	exit
+fi
+cmd=$1; shift
+case "$cmd" in
+	sign) sign "$@";;
+	verify) verify "$@";;
+	*) err 1 "%s: Unknown command '%s'\n" "$prog" "$cmd";;
+esac

--- a/examples/binary-signing/rdf.awk
+++ b/examples/binary-signing/rdf.awk
@@ -1,0 +1,75 @@
+# rdf.awk - Parse RDF N-Quads in AWK
+# Copyright 2021 Spruce Systems, Inc.
+# Apache License, Version 2.0
+#
+# Resources:
+# - https://www.w3.org/TR/n-quads/#sec-grammar
+# - https://pubs.opengroup.org/onlinepubs/9699919799/utilities/awk.html
+
+# RDF statements are parsed from input records into four global arrays:
+#   SUBJECTS, PREDICATES, OBJECTS, GRAPH_LABELS
+
+$NF != "." {
+	printf "%d: Missing \".\" at end\n", NR > "/dev/stderr"
+	exit 1
+}
+
+{
+	subject = $1
+	predicate = $2
+	if (match($0, /".*"/)) {
+		# Parse object term which may contain spaces,
+		# so that space can still be used as field separator.
+		object = substr($0, RSTART, RLENGTH)
+		sub(/".*"/, "STRING")
+	} else {
+		object = $3
+	}
+	if (NF == 5) {
+		graph_label = $4
+	} else if (NF == 4) {
+		graph_label = ""
+	} else {
+		printf "%d: Unexpected number of fields: %d\n", NR, NF > "/dev/stderr"
+		exit 1
+	}
+	# Store statement terms across four global variables.
+	SUBJECTS[NR] = subject
+	PREDICATES[NR] = predicate
+	OBJECTS[NR] = object
+	GRAPH_LABELS[NR] = graph_label
+}
+
+# Select RDF statements matching the given subject, predicate, object, and/or
+# graph label. Put results in the passed results array, with index starting at
+# 1 and value equal to the row number of the matching statement. Return the
+# number of matched statements.
+function select_statements(subject, predicate, object, graph_label, results) {
+	num_results = 0
+	for (i = 0; i <= NR; i++) {
+		if        ((    subject == "*" || subject == SUBJECTS[i]) \
+			&& (  predicate == "*" || predicate == PREDICATES[i]) \
+			&& (     object == "*" || object == OBJECTS[i]) \
+			&& (graph_label == "*" || graph_label == GRAPH_LABELS[i]) \
+		) {
+			results[++num_results] = i
+		}
+	}
+	return num_results
+}
+
+# Select an RDF statement matching the given subject, predicate, object, and/or
+# graph label. Return the row number of the matched statement. Exit with an
+# error if no statement matched or if more than one statement matched.
+function select_statement(subject, predicate, object, graph_label) {
+	n = select_statements(subject, predicate, object, graph_label, results)
+	if (n == 0) {
+		printf "Found no matching statement for (%s, %s, %s, %s)\n", subject, predicate, object, graph_label > "/dev/stderr"
+		exit 1
+	}
+	if (n > 1) {
+		printf "Found multiple statements for (%s, %s, %s, %s)\n", subject, predicate, object, graph_label > "/dev/stderr"
+		exit 1
+	}
+	return results[1]
+}

--- a/examples/binary-signing/verify.awk
+++ b/examples/binary-signing/verify.awk
@@ -1,0 +1,39 @@
+# Depends on: rdf.awk
+
+END {
+	vc_id = SUBJECTS[select_statement("*", "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>", "<https://www.w3.org/2018/credentials#VerifiableCredential>", "")]
+	sub_id = OBJECTS[select_statement(vc_id, "<https://www.w3.org/2018/credentials#credentialSubject>", "*", "")]
+	size_term = OBJECTS[select_statement(sub_id, "<https://schema.org/contentSize>", "*", "")]
+	if (!match(size_term, /^"[0-9]+B"$/)) {
+		printf "Unable to match size: %s\n", size_term > "/dev/stderr"
+		exit 1
+	}
+	size_bytes = substr(size_term, 2, RLENGTH-3)
+	#format_term = OBJECTS[select_statement(sub_id, "<https://schema.org/encodingFormat>", "*", "")]
+	digest_id = OBJECTS[select_statement(sub_id, "<https://w3id.org/security#digest>", "*", "")]
+	select_statement(digest_id, "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>", "<https://w3id.org/security#Digest>", "")
+	select_statement(digest_id, "<https://w3id.org/security#digestAlgorithm>", "<http://www.w3.org/2001/04/xmlenc#sha256>", "")
+	digest_value_term = OBJECTS[select_statement(digest_id, "<https://w3id.org/security#digestValue>", "*", "")]
+	if (!match(digest_value_term, /^"[0-9a-f]+"$/)) {
+		printf "Unable to match digest: %s\n", digest_value_term > "/dev/stderr"
+		exit 1
+	}
+	digest_hex = substr(digest_value_term, 2, 64)
+	if (("wc -c " file) | getline < 0) {
+		print "Unable to calculate file size" > "/dev/stderr"
+		exit 1
+	}
+	if ($1 != size_bytes) {
+		printf "File size mismatch. Credential said: %d, but we counted %d.\n", size_bytes, $1 > "/dev/stderr"
+		exit 1
+	}
+	if (("shasum -a 256 " file) | getline < 0) {
+		print "Unable to calculate file digest" > "/dev/stderr"
+		exit 1
+	}
+	if ($1 != digest_hex) {
+		printf "Digest mismatch. Credential said: %s, but we calculated %s.\n", digest_hex, $1 > "/dev/stderr"
+		exit 1
+	}
+	print "\033[1;32m✓\033[0m File size and digest verified." > "/dev/stderr"
+}


### PR DESCRIPTION
This adds an example of using a Verifiable Credential to assert a content hash and file size.
A shell script uses DIDKit to do signing and verifying, with some AWK for parsing and verifying the claims.
This uses the `didkit to-rdf-urdna2015` subcommand, so includes commits from #172.