### PR TITLE
Generate DID Test Suite vectors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         repository: spruceid/ssi
         path: ssi
-        ref: 178cb589266de702933c581ce2be3d4a7fcd3c0c
+        ref: 7b30faee856f9288a806d557ec1d14ced9b0cea0
         submodules: true
 
     - name: Cache Cargo registry and build artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         repository: spruceid/ssi
         path: ssi
-        ref: 65b7a394bb753d4cdfeafd8ae9b040be557e0973
+        ref: d67bcf0ea36269cab175475639485c6f564105d5
         submodules: true
 
     - name: Cache Cargo registry and build artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         repository: spruceid/ssi
         path: ssi
-        ref: d67bcf0ea36269cab175475639485c6f564105d5
+        ref: 178cb589266de702933c581ce2be3d4a7fcd3c0c
         submodules: true
 
     - name: Cache Cargo registry and build artifacts

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -13,8 +13,8 @@ use didkit::{
 };
 use didkit_cli::opts::ResolverOptions;
 use ssi::did_resolve::{
-    ERROR_INVALID_DID, ERROR_NOT_FOUND, ERROR_REPRESENTATION_NOT_SUPPORTED, TYPE_DID_LD_JSON,
-    TYPE_DID_RESOLUTION,
+    ERROR_INVALID_DID, ERROR_INVALID_DID_URL, ERROR_NOT_FOUND, ERROR_REPRESENTATION_NOT_SUPPORTED,
+    TYPE_DID_LD_JSON, TYPE_DID_RESOLUTION,
 };
 
 pub mod accept;
@@ -501,12 +501,14 @@ impl DIDKitHTTPSvc {
                 parts.status = match &error[..] {
                     ERROR_NOT_FOUND => StatusCode::NOT_FOUND,
                     ERROR_INVALID_DID => StatusCode::BAD_REQUEST,
+                    ERROR_INVALID_DID_URL => StatusCode::BAD_REQUEST,
                     ERROR_REPRESENTATION_NOT_SUPPORTED => StatusCode::NOT_ACCEPTABLE,
                     _ => StatusCode::INTERNAL_SERVER_ERROR,
                 };
                 body = Body::from(error.as_bytes().to_vec());
             }
             if let ContentMetadata::DIDDocument(ref did_doc_meta) = content_meta {
+                // 1.9
                 if did_doc_meta.deactivated == Some(true) {
                     parts.status = StatusCode::GONE;
                 }

--- a/lib/examples/did-test-suite.rs
+++ b/lib/examples/did-test-suite.rs
@@ -500,6 +500,12 @@ async fn report_resolver_tz() {
             .await;
     }
 
+    for did in vec!["did:tz:tz1YwA1FwpgLtc1G8DKbbZ6e6PTb1dQMRn5x"] {
+        report
+            .resolve_representation(&did_tz, did, &ResolutionInputMetadata::default())
+            .await;
+    }
+
     let writer = std::io::BufWriter::new(std::io::stdout());
     serde_json::to_writer_pretty(writer, &report).unwrap();
 }

--- a/lib/examples/did-test-suite.rs
+++ b/lib/examples/did-test-suite.rs
@@ -158,18 +158,19 @@ async fn did_method_vector(resolver: &dyn DIDResolver, did: &str) -> DIDVector {
         .await;
     assert_eq!(res_meta.error, None);
     let doc_meta = doc_meta_opt.unwrap();
-    let content_type = res_meta.content_type.clone().unwrap();
-    assert_eq!(content_type, TYPE_DID_LD_JSON);
+    assert_eq!(res_meta.content_type, None);
     let mut did_data = Map::new();
 
     let input_meta = ResolutionInputMetadata {
-        accept: Some(content_type.clone()),
+        accept: Some(TYPE_DID_LD_JSON.to_string()),
         ..Default::default()
     };
     let (res_repr_meta, doc_repr, _doc_repr_meta_opt) =
         resolver.resolve_representation(did, &input_meta).await;
     assert_eq!(res_repr_meta.error, None);
     let representation = String::from_utf8(doc_repr).unwrap();
+    let content_type = res_repr_meta.content_type.clone().unwrap();
+    assert_eq!(content_type, TYPE_DID_LD_JSON);
 
     let mut doc_value = serde_json::to_value(doc).unwrap();
     let mut representation_specific_entries = RepresentationSpecificEntries::default();
@@ -187,7 +188,7 @@ async fn did_method_vector(resolver: &dyn DIDResolver, did: &str) -> DIDVector {
         },
         representation,
         did_document_metadata: doc_meta,
-        did_resolution_metadata: res_meta,
+        did_resolution_metadata: res_repr_meta,
     };
     did_data.insert(content_type, resolution_result);
     let did_vector = DIDVector {

--- a/lib/examples/did-test-suite.rs
+++ b/lib/examples/did-test-suite.rs
@@ -517,7 +517,7 @@ async fn report_resolver_key() {
         "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH", // Ed25519
         "did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme", // Secp256k1
         "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169", // Secp256r1
-        "did:key;invalid",
+        "did:key;invalid", // should return invalidDid error
     ] {
         report
             .resolve(

--- a/lib/examples/did-test-suite.rs
+++ b/lib/examples/did-test-suite.rs
@@ -718,7 +718,11 @@ async fn report_dereferencer_web() {
         executions: Vec::new(),
     };
 
-    for did_url in vec!["did:web:did.actor:nonexistent"] {
+    for did_url in vec![
+        "did:web:did.actor:nonexistent",
+        "did:web:demo.spruceid.com:2021:07:14:service-example",
+        "did:web:demo.spruceid.com:2021:07:14:service-example?service=hello",
+    ] {
         report
             .dereference(
                 &did_web::DIDWeb,

--- a/lib/examples/did-test-suite.rs
+++ b/lib/examples/did-test-suite.rs
@@ -25,6 +25,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{BTreeMap as Map, HashMap};
 use std::env::Args;
+use std::str::FromStr;
 
 use ssi::did::{Document, DIDURL};
 use ssi::did_resolve::{
@@ -212,8 +213,6 @@ async fn did_method_vector(resolver: &dyn DIDResolver, did: &str) -> DIDVector {
 
 async fn report_method_key() {
     let did_parameters = Map::new();
-    // No parameters supported for did:key
-    // did_parameters.insert("".to_string(), DIDURL::from_str("").unrwap());
     let mut did_vectors = Map::new();
     let supported_content_types = vec![TYPE_DID_LD_JSON.to_string()];
 
@@ -241,9 +240,13 @@ async fn report_method_key() {
 }
 
 async fn report_method_web() {
-    let did_parameters = Map::new();
-    // No parameters supported for did:web
-    // did_parameters.insert("".to_string(), DIDURL::from_str("").unrwap());
+    let mut did_parameters = Map::new();
+    did_parameters.insert(
+        "service".to_string(),
+        DIDURL::from_str("did:web:demo.spruceid.com:2021:07:14:service-example?service=hello")
+            .unwrap(),
+    );
+
     let mut did_vectors = Map::new();
     let supported_content_types = vec![TYPE_DID_LD_JSON.to_string()];
 

--- a/lib/examples/did-test-suite.rs
+++ b/lib/examples/did-test-suite.rs
@@ -3,13 +3,22 @@ To generate test vectors:
     ln -s ../did-test-suite/packages/did-core-test-server/suites/implementations impl
     cargo run --example did-test-suite method key > impl/did-key-spruce.json
     cargo run --example did-test-suite method web > impl/did-web-spruce.json
-    cargo run --example did-test-suite method tz > impl/did-tz.json
+    cargo run --example did-test-suite method tz > impl/did-tz-spruce.json
+    cargo run --example did-test-suite method onion > impl/did-onion-spruce.json
+    cargo run --example did-test-suite method pkh > impl/did-pkh-spruce.json
+    cargo run --example did-test-suite method webkey > impl/did-webkey-spruce.json
     cargo run --example did-test-suite resolver key > impl/resolver-spruce-key.json
     cargo run --example did-test-suite resolver web > impl/resolver-spruce-web.json
     cargo run --example did-test-suite resolver tz > impl/resolver-spruce-tz.json
+    cargo run --example did-test-suite resolver onion > impl/resolver-spruce-onion.json
+    cargo run --example did-test-suite resolver pkh > impl/resolver-spruce-pkh.json
+    cargo run --example did-test-suite resolver webkey > impl/resolver-spruce-webkey.json
     cargo run --example did-test-suite dereferencer key > impl/dereferencer-spruce-key.json
     cargo run --example did-test-suite dereferencer web > impl/dereferencer-spruce-web.json
     cargo run --example did-test-suite dereferencer tz > impl/dereferencer-spruce-tz.json
+    cargo run --example did-test-suite dereferencer onion > impl/dereferencer-spruce-onion.json
+    cargo run --example did-test-suite dereferencer pkh > impl/dereferencer-spruce-pkh.json
+    cargo run --example did-test-suite dereferencer webkey > impl/dereferencer-spruce-webkey.json
 */
 
 use serde::{Deserialize, Serialize};
@@ -286,6 +295,88 @@ async fn report_method_tz() {
     serde_json::to_writer_pretty(writer, &report).unwrap();
 }
 
+async fn report_method_onion() {
+    let resolver = did_onion::DIDOnion::default();
+    let did_parameters = Map::new();
+    let mut did_vectors = Map::new();
+    let supported_content_types = vec![TYPE_DID_LD_JSON.to_string()];
+
+    for did in vec!["did:onion:fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid"] {
+        let did_vector = did_method_vector(&resolver, did).await;
+        did_vectors.insert(did.to_string(), did_vector);
+    }
+
+    let dids = did_vectors.keys().cloned().collect();
+    let report = DIDImplementation {
+        did_method: "did:onion".to_string(),
+        implementation: "https://github.com/spruceid/ssi/tree/main/did-onion".to_string(),
+        implementer: "Spruce Systems, Inc.".to_string(),
+        supported_content_types,
+        dids,
+        did_parameters,
+        did_vectors,
+    };
+    let writer = std::io::BufWriter::new(std::io::stdout());
+    serde_json::to_writer_pretty(writer, &report).unwrap();
+}
+
+async fn report_method_pkh() {
+    let resolver = did_pkh::DIDPKH;
+    let did_parameters = Map::new();
+    let mut did_vectors = Map::new();
+    let supported_content_types = vec![TYPE_DID_LD_JSON.to_string()];
+
+    for did in vec![
+        "did:pkh:doge:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L",
+        "did:pkh:tz:tz1YwA1FwpgLtc1G8DKbbZ6e6PTb1dQMRn5x",
+        "did:pkh:eth:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+        "did:pkh:btc:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6",
+        "did:pkh:celo:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011",
+        "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+    ] {
+        let did_vector = did_method_vector(&resolver, did).await;
+        did_vectors.insert(did.to_string(), did_vector);
+    }
+
+    let dids = did_vectors.keys().cloned().collect();
+    let report = DIDImplementation {
+        did_method: "did:pkh".to_string(),
+        implementation: "https://github.com/spruceid/ssi/tree/main/did-pkh".to_string(),
+        implementer: "Spruce Systems, Inc.".to_string(),
+        supported_content_types,
+        dids,
+        did_parameters,
+        did_vectors,
+    };
+    let writer = std::io::BufWriter::new(std::io::stdout());
+    serde_json::to_writer_pretty(writer, &report).unwrap();
+}
+
+async fn report_method_webkey() {
+    let resolver = did_webkey::DIDWebKey;
+    let did_parameters = Map::new();
+    let mut did_vectors = Map::new();
+    let supported_content_types = vec![TYPE_DID_LD_JSON.to_string()];
+
+    for did in vec!["did:webkey:ssh:demo.spruceid.com:2021:07:14:keys"] {
+        let did_vector = did_method_vector(&resolver, did).await;
+        did_vectors.insert(did.to_string(), did_vector);
+    }
+
+    let dids = did_vectors.keys().cloned().collect();
+    let report = DIDImplementation {
+        did_method: "did:webkey".to_string(),
+        implementation: "https://github.com/spruceid/ssi/tree/main/did-webkey".to_string(),
+        implementer: "Spruce Systems, Inc.".to_string(),
+        supported_content_types,
+        dids,
+        did_parameters,
+        did_vectors,
+    };
+    let writer = std::io::BufWriter::new(std::io::stdout());
+    serde_json::to_writer_pretty(writer, &report).unwrap();
+}
+
 impl ResolverOutcome {
     fn from_error_or_deactivated(error: Option<String>, deactivated: Option<bool>) -> Self {
         if let Some(error) = error {
@@ -510,6 +601,84 @@ async fn report_resolver_tz() {
     serde_json::to_writer_pretty(writer, &report).unwrap();
 }
 
+async fn report_resolver_onion() {
+    let resolver = did_onion::DIDOnion::default();
+    let mut report = DIDResolverImplementation {
+        did_method: "did:onion".to_string(),
+        implementation: "https://github.com/spruceid/ssi/tree/main/did-onion".to_string(),
+        implementer: "Spruce Systems, Inc.".to_string(),
+        expected_outcomes: HashMap::new(),
+        executions: Vec::new(),
+    };
+
+    for did in vec!["did:onion:fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid"] {
+        report
+            .resolve(&resolver, did, &ResolutionInputMetadata::default())
+            .await;
+    }
+
+    for did in vec!["did:onion:fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid"] {
+        report
+            .resolve_representation(&resolver, did, &ResolutionInputMetadata::default())
+            .await;
+    }
+
+    let writer = std::io::BufWriter::new(std::io::stdout());
+    serde_json::to_writer_pretty(writer, &report).unwrap();
+}
+
+async fn report_resolver_pkh() {
+    let resolver = did_pkh::DIDPKH;
+    let mut report = DIDResolverImplementation {
+        did_method: "did:pkh".to_string(),
+        implementation: "https://github.com/spruceid/ssi/tree/main/did-pkh".to_string(),
+        implementer: "Spruce Systems, Inc.".to_string(),
+        expected_outcomes: HashMap::new(),
+        executions: Vec::new(),
+    };
+
+    for did in vec!["did:pkh:doge:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L"] {
+        report
+            .resolve(&resolver, did, &ResolutionInputMetadata::default())
+            .await;
+    }
+
+    for did in vec!["did:pkh:doge:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L"] {
+        report
+            .resolve_representation(&resolver, did, &ResolutionInputMetadata::default())
+            .await;
+    }
+
+    let writer = std::io::BufWriter::new(std::io::stdout());
+    serde_json::to_writer_pretty(writer, &report).unwrap();
+}
+
+async fn report_resolver_webkey() {
+    let resolver = did_webkey::DIDWebKey;
+    let mut report = DIDResolverImplementation {
+        did_method: "did:webkey".to_string(),
+        implementation: "https://github.com/spruceid/ssi/tree/main/did-webkey".to_string(),
+        implementer: "Spruce Systems, Inc.".to_string(),
+        expected_outcomes: HashMap::new(),
+        executions: Vec::new(),
+    };
+
+    for did in vec!["did:webkey:ssh:demo.spruceid.com:2021:07:14:keys"] {
+        report
+            .resolve(&resolver, did, &ResolutionInputMetadata::default())
+            .await;
+    }
+
+    for did in vec!["did:webkey:ssh:demo.spruceid.com:2021:07:14:keys"] {
+        report
+            .resolve_representation(&resolver, did, &ResolutionInputMetadata::default())
+            .await;
+    }
+
+    let writer = std::io::BufWriter::new(std::io::stdout());
+    serde_json::to_writer_pretty(writer, &report).unwrap();
+}
+
 async fn report_dereferencer_key() {
     let mut report = DIDResolverImplementation {
         did_method: "did:key".to_string(),
@@ -582,6 +751,75 @@ async fn report_dereferencer_tz() {
     serde_json::to_writer_pretty(writer, &report).unwrap();
 }
 
+async fn report_dereferencer_onion() {
+    let resolver = did_onion::DIDOnion::default();
+    let mut report = DIDResolverImplementation {
+        did_method: "did:onion".to_string(),
+        implementation: "https://github.com/spruceid/ssi/tree/main/did-onion".to_string(),
+        implementer: "Spruce Systems, Inc.".to_string(),
+        expected_outcomes: HashMap::new(),
+        executions: Vec::new(),
+    };
+
+    for did_url in vec![
+        "did:onion:fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid",
+        "did:onion:fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid#g7r2t9G8dBBnG7yZkD8sly3ImDlrntB25s2pGuaD97E"
+    ] {
+        report
+            .dereference(&resolver, did_url, &DereferencingInputMetadata::default())
+            .await;
+    }
+
+    let writer = std::io::BufWriter::new(std::io::stdout());
+    serde_json::to_writer_pretty(writer, &report).unwrap();
+}
+
+async fn report_dereferencer_pkh() {
+    let resolver = did_pkh::DIDPKH;
+    let mut report = DIDResolverImplementation {
+        did_method: "did:pkh".to_string(),
+        implementation: "https://github.com/spruceid/ssi/tree/main/did-pkh".to_string(),
+        implementer: "Spruce Systems, Inc.".to_string(),
+        expected_outcomes: HashMap::new(),
+        executions: Vec::new(),
+    };
+
+    for did_url in vec![
+        "did:pkh:doge:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L",
+        "did:pkh:doge:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L#blockchainAccountId",
+    ] {
+        report
+            .dereference(&resolver, did_url, &DereferencingInputMetadata::default())
+            .await;
+    }
+
+    let writer = std::io::BufWriter::new(std::io::stdout());
+    serde_json::to_writer_pretty(writer, &report).unwrap();
+}
+
+async fn report_dereferencer_webkey() {
+    let resolver = did_webkey::DIDWebKey;
+    let mut report = DIDResolverImplementation {
+        did_method: "did:webkey".to_string(),
+        implementation: "https://github.com/spruceid/ssi/tree/main/did-webkey".to_string(),
+        implementer: "Spruce Systems, Inc.".to_string(),
+        expected_outcomes: HashMap::new(),
+        executions: Vec::new(),
+    };
+
+    for did_url in vec![
+        "did:webkey:ssh:demo.spruceid.com:2021:07:14:keys",
+        "did:webkey:ssh:demo.spruceid.com:2021:07:14:keys#b2sb-RCkrCm9c569tNc76JBbirQiR9WCL6kf8GlqbvQ"
+    ] {
+        report
+            .dereference(&resolver, did_url, &DereferencingInputMetadata::default())
+            .await;
+    }
+
+    let writer = std::io::BufWriter::new(std::io::stdout());
+    serde_json::to_writer_pretty(writer, &report).unwrap();
+}
+
 async fn report_method(mut args: Args) {
     let method = args.next().expect("expected method argument");
     args.next().ok_or(()).expect_err("unexpected argument");
@@ -589,6 +827,9 @@ async fn report_method(mut args: Args) {
         "key" => report_method_key().await,
         "web" => report_method_web().await,
         "tz" => report_method_tz().await,
+        "onion" => report_method_onion().await,
+        "pkh" => report_method_pkh().await,
+        "webkey" => report_method_webkey().await,
         method => panic!("unknown method {}", method),
     }
 }
@@ -600,6 +841,9 @@ async fn report_resolver(mut args: Args) {
         "key" => report_resolver_key().await,
         "web" => report_resolver_web().await,
         "tz" => report_resolver_tz().await,
+        "onion" => report_resolver_onion().await,
+        "pkh" => report_resolver_pkh().await,
+        "webkey" => report_resolver_webkey().await,
         method => panic!("unknown method {}", method),
     }
 }
@@ -611,6 +855,9 @@ async fn report_dereferencer(mut args: Args) {
         "key" => report_dereferencer_key().await,
         "web" => report_dereferencer_web().await,
         "tz" => report_dereferencer_tz().await,
+        "onion" => report_dereferencer_onion().await,
+        "pkh" => report_dereferencer_pkh().await,
+        "webkey" => report_dereferencer_webkey().await,
         method => panic!("unknown method {}", method),
     }
 }

--- a/lib/examples/did-test-suite.rs
+++ b/lib/examples/did-test-suite.rs
@@ -220,7 +220,7 @@ async fn report_method_key() {
     let dids = did_vectors.keys().cloned().collect();
     let report = DIDImplementation {
         did_method: "did:key".to_string(),
-        implementation: "ssi/didkit".to_string(),
+        implementation: "https://github.com/spruceid/ssi/tree/main/did-key".to_string(),
         implementer: "Spruce Systems, Inc.".to_string(),
         supported_content_types,
         dids,
@@ -245,7 +245,7 @@ async fn report_method_web() {
     let dids = did_vectors.keys().cloned().collect();
     let report = DIDImplementation {
         did_method: "did:web".to_string(),
-        implementation: "ssi/didkit".to_string(),
+        implementation: "https://github.com/spruceid/ssi/tree/main/did-web".to_string(),
         implementer: "Spruce Systems, Inc.".to_string(),
         supported_content_types,
         dids,
@@ -275,7 +275,7 @@ async fn report_method_tz() {
     let dids = did_vectors.keys().cloned().collect();
     let report = DIDImplementation {
         did_method: "did:tz".to_string(),
-        implementation: "ssi/didkit".to_string(),
+        implementation: "https://github.com/spruceid/ssi/tree/main/did-tezos".to_string(),
         implementer: "Spruce Systems, Inc.".to_string(),
         supported_content_types,
         dids,
@@ -416,7 +416,7 @@ impl DIDResolverImplementation {
 async fn report_resolver_key() {
     let mut report = DIDResolverImplementation {
         did_method: "did:key".to_string(),
-        implementation: "ssi/didkit".to_string(),
+        implementation: "https://github.com/spruceid/ssi/tree/main/did-key".to_string(),
         implementer: "Spruce Systems, Inc.".to_string(),
         expected_outcomes: HashMap::new(),
         executions: Vec::new(),
@@ -454,7 +454,7 @@ async fn report_resolver_key() {
 async fn report_resolver_web() {
     let mut report = DIDResolverImplementation {
         did_method: "did:web".to_string(),
-        implementation: "ssi/didkit".to_string(),
+        implementation: "https://github.com/spruceid/ssi/tree/main/did-web".to_string(),
         implementer: "Spruce Systems, Inc.".to_string(),
         expected_outcomes: HashMap::new(),
         executions: Vec::new(),
@@ -483,7 +483,7 @@ async fn report_resolver_tz() {
     let did_tz = did_tz::DIDTz::default();
     let mut report = DIDResolverImplementation {
         did_method: "did:tz".to_string(),
-        implementation: "ssi/didkit".to_string(),
+        implementation: "https://github.com/spruceid/ssi/tree/main/did-tezos".to_string(),
         implementer: "Spruce Systems, Inc.".to_string(),
         expected_outcomes: HashMap::new(),
         executions: Vec::new(),
@@ -513,7 +513,7 @@ async fn report_resolver_tz() {
 async fn report_dereferencer_key() {
     let mut report = DIDResolverImplementation {
         did_method: "did:key".to_string(),
-        implementation: "ssi/didkit".to_string(),
+        implementation: "https://github.com/spruceid/ssi/tree/main/did-key".to_string(),
         implementer: "Spruce Systems, Inc.".to_string(),
         expected_outcomes: HashMap::new(),
         executions: Vec::new(),
@@ -540,7 +540,7 @@ async fn report_dereferencer_key() {
 async fn report_dereferencer_web() {
     let mut report = DIDResolverImplementation {
         did_method: "did:web".to_string(),
-        implementation: "ssi/didkit".to_string(),
+        implementation: "https://github.com/spruceid/ssi/tree/main/did-web".to_string(),
         implementer: "Spruce Systems, Inc.".to_string(),
         expected_outcomes: HashMap::new(),
         executions: Vec::new(),
@@ -564,7 +564,7 @@ async fn report_dereferencer_tz() {
     let did_tz = did_tz::DIDTz::default();
     let mut report = DIDResolverImplementation {
         did_method: "did:tz".to_string(),
-        implementation: "ssi/didkit".to_string(),
+        implementation: "https://github.com/spruceid/ssi/tree/main/did-tezos".to_string(),
         implementer: "Spruce Systems, Inc.".to_string(),
         expected_outcomes: HashMap::new(),
         executions: Vec::new(),

--- a/lib/examples/did-test-suite.rs
+++ b/lib/examples/did-test-suite.rs
@@ -1,0 +1,419 @@
+/*
+To generate test vectors:
+    ln -s ../did-test-suite/packages/did-core-test-server/suites/implementations impl
+    cargo run --example did-test-suite method key > impl/did-key-spruce.json
+    cargo run --example did-test-suite method web > impl/did-web-spruce.json
+    cargo run --example did-test-suite resolver key > impl/resolver-spruce-key.json
+    cargo run --example did-test-suite resolver web > impl/resolver-spruce-web.json
+*/
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::{BTreeMap as Map, HashMap};
+use std::env::Args;
+
+use ssi::did::{Document, DIDURL};
+use ssi::did_resolve::{
+    DIDResolver, DocumentMetadata, ResolutionInputMetadata, ResolutionMetadata, ResolutionResult,
+    ERROR_INVALID_DID, ERROR_METHOD_NOT_SUPPORTED, ERROR_NOT_FOUND,
+    ERROR_REPRESENTATION_NOT_SUPPORTED, ERROR_UNAUTHORIZED, TYPE_DID_LD_JSON, TYPE_LD_JSON,
+};
+
+type DID = String;
+type ContentType = String;
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RepresentationSpecificEntries {
+    #[serde(rename = "@context")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DIDDocumentDataModel {
+    pub properties: Map<String, Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DIDDocumentDataModel2 {
+    pub representation_specific_entries: RepresentationSpecificEntries,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DIDData {
+    pub did_document_data_model: DIDDocumentDataModel2,
+    pub representation: String,
+    pub did_document_metadata: DocumentMetadata,
+    pub did_resolution_metadata: ResolutionMetadata,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DIDVector {
+    pub did_document_data_model: DIDDocumentDataModel,
+    #[serde(flatten)]
+    pub did_data: Map<ContentType, DIDData>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DIDImplementation {
+    pub did_method: String,
+    pub implementation: String,
+    pub implementer: String,
+    pub supported_content_types: Vec<ContentType>,
+    pub dids: Vec<DID>,
+    pub did_parameters: Map<String, DIDURL>,
+    #[serde(flatten)]
+    pub did_vectors: Map<DID, DIDVector>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub enum ResolverOutcome {
+    DefaultOutcome,
+    #[serde(rename = "invalidDidErrorOutcome")]
+    InvalidDIDErrorOutcome,
+    #[serde(rename = "invalidDidUrlErrorOutcome")]
+    InvalidDIDURLErrorOutcome,
+    NotFoundErrorOutcome,
+    RepresentationNotSupportedErrorOutcome,
+    DeactivatedOutcome,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum ResolverFunction {
+    Resolve,
+    ResolveRepresentation,
+    Dereference,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolverInput {
+    pub did: DID,
+    pub resolution_options: ResolutionInputMetadata,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolverOutput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub did_document: Option<Document>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub did_document_stream: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub did_resolution_metadata: Option<ResolutionMetadata>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub did_document_metadata: Option<DocumentMetadata>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolverExecution {
+    pub function: ResolverFunction,
+    pub input: ResolverInput,
+    pub output: ResolverOutput,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DIDResolverImplementation {
+    pub did_method: String,
+    pub implementation: String,
+    pub implementer: String,
+    pub expected_outcomes: HashMap<ResolverOutcome, Vec<usize>>,
+    pub executions: Vec<ResolverExecution>,
+}
+
+async fn did_method_vector(resolver: &dyn DIDResolver, did: &str) -> DIDVector {
+    let (res_meta, doc, doc_meta_opt) = resolver
+        .resolve(did, &ResolutionInputMetadata::default())
+        .await;
+    assert_eq!(res_meta.error, None);
+    let doc_meta = doc_meta_opt.unwrap();
+    let content_type = res_meta.content_type.clone().unwrap();
+    assert_eq!(content_type, TYPE_DID_LD_JSON);
+    let mut did_data = Map::new();
+
+    let input_meta = ResolutionInputMetadata {
+        accept: Some(content_type.clone()),
+        ..Default::default()
+    };
+    let (res_repr_meta, doc_repr, _doc_repr_meta_opt) =
+        resolver.resolve_representation(did, &input_meta).await;
+    assert_eq!(res_repr_meta.error, None);
+    let representation = String::from_utf8(doc_repr).unwrap();
+
+    let mut doc_value = serde_json::to_value(doc).unwrap();
+    let mut representation_specific_entries = RepresentationSpecificEntries::default();
+    match &content_type[..] {
+        TYPE_DID_LD_JSON => {
+            representation_specific_entries.context =
+                doc_value.as_object_mut().unwrap().remove("@context");
+        }
+        _ => unreachable!(),
+    }
+    let properties: Map<String, Value> = serde_json::from_value(doc_value).unwrap();
+    let resolution_result = DIDData {
+        did_document_data_model: DIDDocumentDataModel2 {
+            representation_specific_entries,
+        },
+        representation,
+        did_document_metadata: doc_meta,
+        did_resolution_metadata: res_meta,
+    };
+    did_data.insert(content_type, resolution_result);
+    let did_vector = DIDVector {
+        did_document_data_model: DIDDocumentDataModel { properties },
+        did_data,
+    };
+    did_vector
+}
+
+async fn report_method_key() {
+    let mut did_parameters = Map::new();
+    // No parameters supported for did:key
+    // did_parameters.insert("".to_string(), DIDURL::from_str("").unrwap());
+    let mut did_vectors = Map::new();
+    let supported_content_types = vec![TYPE_DID_LD_JSON.to_string()];
+
+    for did in vec![
+        "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH", // Ed25519
+        "did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme", // Secp256k1
+        "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169", // Secp256r1
+    ] {
+        let did_vector = did_method_vector(&did_method_key::DIDKey, did).await;
+        did_vectors.insert(did.to_string(), did_vector);
+    }
+
+    let dids = did_vectors.keys().cloned().collect();
+    let report = DIDImplementation {
+        did_method: "did:key".to_string(),
+        implementation: "ssi/didkit".to_string(),
+        implementer: "Spruce Systems, Inc.".to_string(),
+        supported_content_types,
+        dids,
+        did_parameters,
+        did_vectors,
+    };
+    let writer = std::io::BufWriter::new(std::io::stdout());
+    serde_json::to_writer_pretty(writer, &report).unwrap();
+}
+
+async fn report_method_web() {
+    let mut did_parameters = Map::new();
+    // No parameters supported for did:web
+    // did_parameters.insert("".to_string(), DIDURL::from_str("").unrwap());
+    let mut did_vectors = Map::new();
+    let supported_content_types = vec![TYPE_DID_LD_JSON.to_string()];
+
+    let did = "did:web:demo.spruceid.com:2021:07:08";
+    let did_vector = did_method_vector(&did_web::DIDWeb, did).await;
+    did_vectors.insert(did.to_string(), did_vector);
+
+    let dids = did_vectors.keys().cloned().collect();
+    let report = DIDImplementation {
+        did_method: "did:web".to_string(),
+        implementation: "ssi/didkit".to_string(),
+        implementer: "Spruce Systems, Inc.".to_string(),
+        supported_content_types,
+        dids,
+        did_parameters,
+        did_vectors,
+    };
+    let writer = std::io::BufWriter::new(std::io::stdout());
+    serde_json::to_writer_pretty(writer, &report).unwrap();
+}
+
+impl ResolverOutcome {
+    fn from_error_or_deactivated(error: Option<String>, deactivated: Option<bool>) -> Self {
+        if let Some(error) = error {
+            match &error[..] {
+                ERROR_INVALID_DID => return Self::InvalidDIDErrorOutcome,
+                ERROR_REPRESENTATION_NOT_SUPPORTED => {
+                    return Self::RepresentationNotSupportedErrorOutcome
+                }
+                ERROR_NOT_FOUND => return Self::NotFoundErrorOutcome,
+                _ => panic!("Unknown outcome for error: {}", error),
+            }
+        }
+        if deactivated == Some(true) {
+            return Self::DeactivatedOutcome;
+        }
+        return Self::DefaultOutcome;
+    }
+}
+
+impl DIDResolverImplementation {
+    async fn resolve(
+        &mut self,
+        resolver: &dyn DIDResolver,
+        did: &str,
+        options: &ResolutionInputMetadata,
+    ) {
+        let (res_meta, doc_opt, doc_meta_opt) = resolver.resolve(did, options).await;
+        let input = ResolverInput {
+            did: did.to_string(),
+            resolution_options: options.to_owned(),
+        };
+        let error_opt = res_meta.error.clone();
+        let doc_meta = doc_meta_opt.unwrap_or_default();
+        let deactivated_opt = doc_meta.deactivated.clone();
+        let output = ResolverOutput {
+            did_document: doc_opt,
+            did_resolution_metadata: Some(res_meta),
+            did_document_metadata: Some(doc_meta),
+            ..Default::default()
+        };
+        let execution = ResolverExecution {
+            function: ResolverFunction::Resolve,
+            input,
+            output,
+        };
+        self.add_execution(execution, error_opt, deactivated_opt);
+    }
+
+    async fn resolve_representation(
+        &mut self,
+        resolver: &dyn DIDResolver,
+        did: &str,
+        options: &ResolutionInputMetadata,
+    ) {
+        let (res_meta, doc_repr, doc_meta_opt) =
+            resolver.resolve_representation(did, options).await;
+        let representation = String::from_utf8(doc_repr).unwrap();
+        let input = ResolverInput {
+            did: did.to_string(),
+            resolution_options: options.to_owned(),
+        };
+        let error_opt = res_meta.error.clone();
+        let doc_meta = doc_meta_opt.unwrap_or_default();
+        let deactivated_opt = doc_meta.deactivated.clone();
+        let output = ResolverOutput {
+            did_document_stream: Some(representation),
+            did_resolution_metadata: Some(res_meta),
+            did_document_metadata: Some(doc_meta),
+            ..Default::default()
+        };
+        let execution = ResolverExecution {
+            function: ResolverFunction::ResolveRepresentation,
+            input,
+            output,
+        };
+        self.add_execution(execution, error_opt, deactivated_opt);
+    }
+
+    fn add_execution(
+        &mut self,
+        execution: ResolverExecution,
+        error_opt: Option<String>,
+        deactivated_opt: Option<bool>,
+    ) {
+        let i = self.executions.len();
+        self.executions.push(execution);
+        let outcome = ResolverOutcome::from_error_or_deactivated(error_opt, deactivated_opt);
+        self.expected_outcomes.entry(outcome).or_default().push(i);
+    }
+}
+
+async fn report_resolver_key() {
+    let mut report = DIDResolverImplementation {
+        did_method: "did:key".to_string(),
+        implementation: "ssi/didkit".to_string(),
+        implementer: "Spruce Systems, Inc.".to_string(),
+        expected_outcomes: HashMap::new(),
+        executions: Vec::new(),
+    };
+
+    for did in vec![
+        "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH", // Ed25519
+        "did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme", // Secp256k1
+        "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169", // Secp256r1
+        "did:key;invalid",
+    ] {
+        report
+            .resolve(
+                &did_method_key::DIDKey,
+                did,
+                &ResolutionInputMetadata::default(),
+            )
+            .await;
+    }
+
+    for did in vec!["did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"] {
+        report
+            .resolve_representation(
+                &did_method_key::DIDKey,
+                did,
+                &ResolutionInputMetadata::default(),
+            )
+            .await;
+    }
+
+    let writer = std::io::BufWriter::new(std::io::stdout());
+    serde_json::to_writer_pretty(writer, &report).unwrap();
+}
+
+async fn report_resolver_web() {
+    let mut report = DIDResolverImplementation {
+        did_method: "did:web".to_string(),
+        implementation: "ssi/didkit".to_string(),
+        implementer: "Spruce Systems, Inc.".to_string(),
+        expected_outcomes: HashMap::new(),
+        executions: Vec::new(),
+    };
+
+    for did in vec![
+        "did:web:identity.foundation",
+        "did:web:did.actor:nonexistent",
+    ] {
+        report
+            .resolve(&did_web::DIDWeb, did, &ResolutionInputMetadata::default())
+            .await;
+    }
+
+    for did in vec!["did:web:identity.foundation"] {
+        report
+            .resolve_representation(&did_web::DIDWeb, did, &ResolutionInputMetadata::default())
+            .await;
+    }
+
+    let writer = std::io::BufWriter::new(std::io::stdout());
+    serde_json::to_writer_pretty(writer, &report).unwrap();
+}
+
+async fn report_method(mut args: std::env::Args) {
+    let method = args.next().expect("expected method argument");
+    match &method[..] {
+        "key" => report_method_key().await,
+        "web" => report_method_web().await,
+        method => panic!("unknown method {}", method),
+    }
+}
+
+async fn report_resolver(mut args: std::env::Args) {
+    let method = args.next().expect("expected method argument");
+    match &method[..] {
+        "key" => report_resolver_key().await,
+        "web" => report_resolver_web().await,
+        method => panic!("unknown method {}", method),
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let mut args = std::env::args();
+    args.next();
+    let section = args.next().expect("expected section argument");
+    match &section[..] {
+        "method" => report_method(args).await,
+        "resolver" => report_resolver(args).await,
+        section => panic!("unknown section {}", section),
+    }
+}

--- a/lib/examples/did-test-suite.rs
+++ b/lib/examples/did-test-suite.rs
@@ -446,26 +446,6 @@ async fn report_resolver_web() {
     serde_json::to_writer_pretty(writer, &report).unwrap();
 }
 
-async fn report_method(mut args: Args) {
-    let method = args.next().expect("expected method argument");
-    args.next().ok_or(()).expect_err("unexpected argument");
-    match &method[..] {
-        "key" => report_method_key().await,
-        "web" => report_method_web().await,
-        method => panic!("unknown method {}", method),
-    }
-}
-
-async fn report_resolver(mut args: Args) {
-    let method = args.next().expect("expected method argument");
-    args.next().ok_or(()).expect_err("unexpected argument");
-    match &method[..] {
-        "key" => report_resolver_key().await,
-        "web" => report_resolver_web().await,
-        method => panic!("unknown method {}", method),
-    }
-}
-
 async fn report_dereferencer_key() {
     let mut report = DIDResolverImplementation {
         did_method: "did:key".to_string(),
@@ -514,6 +494,26 @@ async fn report_dereferencer_web() {
 
     let writer = std::io::BufWriter::new(std::io::stdout());
     serde_json::to_writer_pretty(writer, &report).unwrap();
+}
+
+async fn report_method(mut args: Args) {
+    let method = args.next().expect("expected method argument");
+    args.next().ok_or(()).expect_err("unexpected argument");
+    match &method[..] {
+        "key" => report_method_key().await,
+        "web" => report_method_web().await,
+        method => panic!("unknown method {}", method),
+    }
+}
+
+async fn report_resolver(mut args: Args) {
+    let method = args.next().expect("expected method argument");
+    args.next().ok_or(()).expect_err("unexpected argument");
+    match &method[..] {
+        "key" => report_resolver_key().await,
+        "web" => report_resolver_web().await,
+        method => panic!("unknown method {}", method),
+    }
 }
 
 async fn report_dereferencer(mut args: Args) {


### PR DESCRIPTION
This PR adds a program using ssi and the ssi's DID method implementations to generate implementation data (test vectors / reports) for use in the [DID Test Suite](https://github.com/w3c/did-test-suite/#adding-your-did-implementation). The program is added as an example script in the `didkit` crate, which takes command-line arguments and outputs the various JSON files to add to the DID Test suite.

- [x] Update ssi: https://github.com/spruceid/ssi/pull/224
- [x] Generate reports for `did:web` and `did:key`
- [x] Generate reports for `did:pkh`, `did:webkey`, `did:tz`, and `did:onion`
- [x] Generate DID URL dereferencer report
- [x] Include DID parameter usage in report data
- [x] Open PR to add to DID Test Suite: https://github.com/w3c/did-test-suite/pull/185