### PR TITLE
Update ssi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         repository: spruceid/ssi
         path: ssi
-        ref: b0900a6d0254caef457161d10653f3ac8f5138d3
+        ref: 65b7a394bb753d4cdfeafd8ae9b040be557e0973
         submodules: true
 
     - name: Cache Cargo registry and build artifacts


### PR DESCRIPTION
This should fix #176, by updating ssi's commit reference used in CI to include changes to `did:tz` merged in https://github.com/spruceid/ssi/pull/219.