### PR TITLE
Fix for statically defined options.data_files build variable for Python library build

### DIFF
--- a/lib/python/didkit/__init__.py
+++ b/lib/python/didkit/__init__.py
@@ -1,20 +1,23 @@
 from ctypes import *
-from sys import platform
+import platform
 from deprecated import deprecated
 import os.path
 
 didkit = None
 didpath = os.path.dirname(os.path.abspath(__file__))
+host_os = platform.system()
 
-if platform == "linux" or platform == "linux2":
+if host_os == "Linux":
     didpath = os.path.join(didpath, 'libdidkit.so')
     didkit = libc = CDLL(didpath)
-elif platform == "darwin":
+elif host_os == "Darwin":
     didpath = os.path.join(didpath, 'libdidkit.dylib')
     didkit = libc = CDLL(didpath)
-else:
-    didpath = os.path.join(didpath, 'libdidkit.dll')
+elif host_os == "Windows":
+    didpath = os.path.join(didpath, 'didkit.dll')
     didkit = libc = CDLL(didpath, winmode=1)
+else:
+    raise RuntimeError("System type %s unsupported."%(host_os))
 
 # String get_version()
 didkit.didkit_get_version.restype = c_char_p

--- a/lib/python/setup.cfg
+++ b/lib/python/setup.cfg
@@ -20,6 +20,3 @@ include_package_data = True
 python_requires = >=3.6
 install_requires =
   deprecated
-
-[options.data_files]
-didkit = didkit/libdidkit.so

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -1,17 +1,20 @@
 #! /usr/bin/env python3
 import os
-from sys import platform
+import platform
 from setuptools import setup, Extension
 
 ##Determine what system we are building on to determine what type of shared object has been built and needs copyingthis differs between OS's (e.g. libdidkit.so vs libdidkit.dylib vs libdidkit.dll)
 didpath = "didkit"
-so_filename = "libdidkit"
-if platform == "linux" or platform == "linux2":
-    LIBDIDKIT_SHARE_OBJ = os.path.join(didpath, '%s.so'%(so_filename))
-elif platform == "darwin":
-    LIBDIDKIT_SHARE_OBJ = os.path.join(didpath, '%s.dylib'%(so_filename))
+host_os = platform.system()
+
+if host_os == "Linux":
+    LIBDIDKIT_SHARE_OBJ = os.path.join(didpath, 'libdidkit.so')
+elif host_os == "Darwin":
+    LIBDIDKIT_SHARE_OBJ = os.path.join(didpath, 'libdidkit.dylib')
+elif host_os == "Windows":
+    LIBDIDKIT_SHARE_OBJ = os.path.join(didpath, 'didkit.dll')
 else:
-    LIBDIDKIT_SHARE_OBJ = os.path.join(didpath, '%s.dll'%(so_filename))
+    raise RuntimeError("System type %s unsupported. Exiting setup."%(host_os))
 
 ## All other static build variables comes from setup.cfg
 setup_args = dict(

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -1,0 +1,21 @@
+#! /usr/bin/env python3
+import os
+from sys import platform
+from setuptools import setup, Extension
+
+##Determine what system we are building on to determine what type of shared object has been built and needs copyingthis differs between OS's (e.g. libdidkit.so vs libdidkit.dylib vs libdidkit.dll)
+didpath = "didkit"
+so_filename = "libdidkit"
+if platform == "linux" or platform == "linux2":
+    LIBDIDKIT_SHARE_OBJ = os.path.join(didpath, '%s.so'%(so_filename))
+elif platform == "darwin":
+    LIBDIDKIT_SHARE_OBJ = os.path.join(didpath, '%s.dylib'%(so_filename))
+else:
+    LIBDIDKIT_SHARE_OBJ = os.path.join(didpath, '%s.dll'%(so_filename))
+
+## All other static build variables comes from setup.cfg
+setup_args = dict(
+    data_files = [ ("" , [LIBDIDKIT_SHARE_OBJ] ) ]
+)
+
+setup(**setup_args)


### PR DESCRIPTION
The current python build process includes a hardcoded filepath to the libdidkit shared object that the python library relies upon: https://github.com/spruceid/didkit/blob/171c99ac2db8276828b2141b0a9ac6be8a580a19/lib/python/setup.cfg#L25 

The hardcoding assumes the python library is being built on a Linux system and the file will have a `.so` extension. Buidling on macOS fails as the python build script tries to copy `libdidkit.so` which doesn't exist, instead it should try to copy `libdidkit.dylib`.

Given the required shared object depends on the system being built it needs to be dynamically determined and has to go into a setup.py rather than being able to defined in a setup.cfg.

Boilerplate fix attached but there a variety of ways to solve this one for sure. 