### PR TITLE
Use URI for verificationMethod option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         repository: spruceid/ssi
         path: ssi
-        ref: a77bbbc7b9528b32d7d9a29107336458bb3612e0
+        ref: a6fecbdcb0414a907973fa7bc54cd66b6557a977
         submodules: true
 
     - name: Cache Cargo registry and build artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,14 +114,14 @@ jobs:
         npm i
         ./vendors/spruce/test.sh
 
-    - name: Checkout vc-http-api v0.0.2
+    - name: Checkout vc-http-api v0.0.3-unstable
       uses: actions/checkout@v2
       with:
         repository: spruceid/vc-http-api
         path: didkit/http/tests/vc-http-api/vc-http-api
-        ref: df9d1bf9540771d114f5b4c4348777378a3f0447
+        ref: 34b8afdc85d5b83c83f05b257e5cef5e5dac5b5c
 
-    - name: Run vc-http-api v0.0.2 test suite
+    - name: Run vc-http-api v0.0.3-unstable test suite
       working-directory: didkit/http/tests/vc-http-api
       run: |
         npm install

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,4 @@
+use std::convert::TryInto;
 use std::fs::File;
 use std::io::{stdin, stdout, BufReader, BufWriter, Read, Write};
 use std::path::PathBuf;
@@ -15,7 +16,7 @@ use didkit::{
     dereference, get_verification_method, runtime, DIDMethod, DIDResolver,
     DereferencingInputMetadata, Error, LinkedDataProofOptions, Metadata, ProofFormat, ProofPurpose,
     ResolutionInputMetadata, ResolutionResult, Source, VerifiableCredential,
-    VerifiablePresentation, DID_METHODS, JWK,
+    VerifiablePresentation, DID_METHODS, JWK, URI,
 };
 use didkit_cli::opts::ResolverOptions;
 
@@ -158,7 +159,7 @@ pub enum DIDKit {
 pub struct ProofOptions {
     // Options as in vc-http-api
     #[structopt(env, short, long)]
-    pub verification_method: Option<String>,
+    pub verification_method: Option<URI>,
     #[structopt(env, short, long)]
     pub proof_purpose: Option<ProofPurpose>,
     #[structopt(env, short, long)]

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -91,10 +91,10 @@ pub async fn pick_key<'a>(
         return keys.values().next();
     }
     let vm = match options.verification_method {
-        Some(ref verification_method) => verification_method,
+        Some(ref verification_method) => verification_method.to_string(),
         None => return keys.values().next(),
     };
-    let public_key = match resolve_key(vm, did_resolver).await {
+    let public_key = match resolve_key(&vm, did_resolver).await {
         Err(_err) => {
             // TODO: return error
             return None;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -32,6 +32,7 @@ pub use ssi::vc::LinkedDataProofOptions;
 pub use ssi::vc::Presentation as VerifiablePresentation;
 pub use ssi::vc::ProofPurpose;
 pub use ssi::vc::VerificationResult;
+pub use ssi::vc::URI;
 
 use core::str::FromStr;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Integrates <https://github.com/spruceid/ssi/pull/234>.

This should fix the currently failing test in vc-http-api: https://github.com/w3c-ccg/vc-http-api/blob/ca2e216/packages/vc-http-api-test-server/__tests__/issueCredential.spec.js#L72

> 6. The Issuer's Issue Credential HTTP API MUST reject if the value of "options.verificationMethod" in the body of the POST request does not exist.

Update vc-http-api in CI to newer version, to test more things (which should be passing), such as this above test.