### PR TITLE
Update for separated vc-http-api-test-suite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,20 +108,20 @@ jobs:
         path: vc-http-api
         ref: eef5ef2bb2321e4eac3f7e82a2adb7ccd4db1982
 
-    - name: Run vc-http-api test suite
+    - name: Run vc-http-api plugfest-2020 test suite
       working-directory: vc-http-api/packages/plugfest-2020
       run: |
         npm i
         ./vendors/spruce/test.sh
 
-    - name: Checkout vc-http-api v0.0.3-unstable
+    - name: Checkout VC HTTP API Test Suite
       uses: actions/checkout@v2
       with:
-        repository: spruceid/vc-http-api
-        path: didkit/http/tests/vc-http-api/vc-http-api
-        ref: 34b8afdc85d5b83c83f05b257e5cef5e5dac5b5c
+        repository: w3c-ccg/vc-http-api-test-suite
+        path: didkit/http/tests/vc-http-api/vc-http-api-test-suite
+        ref: 61d498cd04c45a22b9578774e6a066b59a8f4e94
 
-    - name: Run vc-http-api v0.0.3-unstable test suite
+    - name: Run VC HTTP API Test Suite
       working-directory: didkit/http/tests/vc-http-api
       run: |
         npm install

--- a/http/tests/vc-http-api/.gitignore
+++ b/http/tests/vc-http-api/.gitignore
@@ -1,2 +1,2 @@
-vc-http-api
+vc-http-api-test-suite
 node_modules

--- a/http/tests/vc-http-api/README.md
+++ b/http/tests/vc-http-api/README.md
@@ -15,7 +15,7 @@ git clone https://github.com/spruceid/ssi --recurse-submodules
 Checkout the `vc-http-api` test server:
 ```sh
 cd didkit/http/tests/vc-http-api
-git clone https://github.com/w3c-ccg/vc-http-api --depth 1
+git clone https://github.com/w3c-ccg/vc-http-api-test-suite --depth 1
 ```
 
 Install `npm` dependencies:
@@ -33,7 +33,7 @@ npm test
 `didkit-http` will automatically build and run on a random port for the duration of the tests. The test suite will issue requests to the `didkit-http` instance.
 
 [git]: https://git-scm.com/
-[vc-http-api-test-server]: https://github.com/w3c-ccg/vc-http-api/tree/df9d1bf9540771d114f5b4c4348777378a3f0447/packages/vc-http-api-test-server
+[vc-http-api-test-server]: https://github.com/w3c-ccg/vc-http-api-test-suite/tree/4042312/packages/vc-http-api-test-server
 [didkit-http]: ../../
 [Cargo]: https://doc.rust-lang.org/cargo/
 [Node.js]: https://nodejs.org/

--- a/http/tests/vc-http-api/package.json
+++ b/http/tests/vc-http-api/package.json
@@ -10,6 +10,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "jest": "^26.6.3",
-    "vc-http-api-test-server": "file:vc-http-api/packages/vc-http-api-test-server"
+    "vc-http-api-test-server": "file:vc-http-api-test-suite/packages/vc-http-api-test-server"
   }
 }

--- a/http/tests/vc-http-api/test.js
+++ b/http/tests/vc-http-api/test.js
@@ -40,7 +40,7 @@ const DIDKitHTTP = require('./didkit-http');
   const { results } = await jest.runCLI(
     {
       json: false,
-      roots: [path.join(__dirname, 'vc-http-api', 'packages', 'vc-http-api-test-server')],
+      roots: [path.join(__dirname, 'vc-http-api-test-suite', 'packages', 'vc-http-api-test-server')],
       globals: JSON.stringify({ suiteConfig: config }),
       testTimeout: 60e3
     },


### PR DESCRIPTION
The VC HTTP API Test Suite was split out of the [vc-http-api](https://github.com/w3c-ccg/vc-http-api) repo, into a separate repo, [vc-http-api-test-suite](https://github.com/w3c-ccg/vc-http-api-test-suite/). This PR updates didkit's testing and instructions to use the VC HTTP API Test Suite at its new location.