### PR TITLE
zcap ld in didkit-wasm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         repository: spruceid/ssi
         path: ssi
-        ref: 3aa4d1a2660e6b963eb2e963782a5602d203e6d1
+        ref: 21c13cc96a28c36fa6d1cb8407fc235035fb9f6d
         submodules: true
 
     - name: Cache Cargo registry and build artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,7 +180,7 @@ jobs:
       with:
         repository: spruceid/ssi
         path: ssi
-        ref: 3aa4d1a2660e6b963eb2e963782a5602d203e6d1
+        ref: 21c13cc96a28c36fa6d1cb8407fc235035fb9f6d
         submodules: true
 
     - name: Cache Cargo registry and build artifacts

--- a/lib/node/Cargo.toml
+++ b/lib/node/Cargo.toml
@@ -13,6 +13,7 @@ neon-build = "0.8.1"
 
 [dependencies]
 serde = "1.0"
+serde_json = "1.0"
 
 [dependencies.ssi]
 version = "0.2.1"

--- a/lib/node/index.d.ts
+++ b/lib/node/index.d.ts
@@ -45,4 +45,17 @@ declare module "didkit" {
   function verifyPresentation(vp: any, options: Options): VerifyResult;
 
   function DIDAuth(did: string, options: Options, key: Key): string;
+
+  function delegateCapability(del: any, options: Options, parents: string[], key: Key): any;
+  function prepareDelegateCapability(del: any, options: Options, parents: string[], key: Key): any;
+  function completeDelegateCapability(del: any, prep: any, sig: string): any;
+  function verifyDelegation(del: any, options: Options): VerifyResult;
+
+  function invokeCapability(inv: any, target: string, options: Options, key: Key): any;
+  function prepareInvokeCapability(inv: any, target: string, options: Options, key: Key): any;
+  function completeInvokeCapability(inv: any, prep: any, sig: string): any;
+  function verifyInvocation(inv: any, del: any, options: Options): VerifyResult;
+  function verifyInvocationSignature(inv: any, options: Options): VerifyResult;
+
+  function jwkFromTezosKey(key: string): Ed25519Key;
 }

--- a/lib/node/src/didkit.rs
+++ b/lib/node/src/didkit.rs
@@ -5,15 +5,21 @@ use didkit::error::Error as DIDKitError;
 use didkit::error::{didkit_error_code, didkit_error_message};
 use didkit::get_verification_method;
 use didkit::runtime;
+use didkit::ProofPreparation;
 use didkit::Source;
 use didkit::VerifiableCredential;
 use didkit::VerifiablePresentation;
 use didkit::DID_METHODS;
 use didkit::JWK;
+use didkit::URI;
+use didkit::{Delegation, Invocation};
 use didkit::{JWTOrLDPOptions, LinkedDataProofOptions, ProofFormat};
 
 use crate::error::Error;
 use crate::{arg, throws};
+
+type GenericInvocation = Invocation<serde_json::Value>;
+type GenericDelegation = Delegation<serde_json::Value>;
 
 pub static VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -146,5 +152,114 @@ pub fn verify_presentation(mut cx: FunctionContext) -> JsResult<JsValue> {
     let rt = throws!(cx, runtime::get())?;
     let result = rt.block_on(vp.verify(Some(options), DID_METHODS.to_resolver()));
     let result = throws!(cx, neon_serde::to_value(&mut cx, &result))?;
+    Ok(result)
+}
+
+pub fn delegate_capability(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let del = arg!(cx, 0, GenericDelegation);
+    let options = arg!(cx, 1, LinkedDataProofOptions);
+    let parents = arg!(cx, 2, Vec<String>);
+    let key = arg!(cx, 3, JWK);
+
+    let rt = throws!(cx, runtime::get())?;
+    let fut = del.generate_proof(
+        &key,
+        &options,
+        &parents.iter().map(|p| p.as_ref()).collect::<Vec<&str>>(),
+    );
+    let result = throws!(cx, neon_serde::to_value(&mut cx, &rt.block_on(fut)))?;
+    Ok(result)
+}
+
+pub fn prepare_delegate_capability(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let del = arg!(cx, 0, GenericDelegation);
+    let options = arg!(cx, 1, LinkedDataProofOptions);
+    let parents = arg!(cx, 2, Vec<String>);
+    let key = arg!(cx, 3, JWK);
+
+    let rt = throws!(cx, runtime::get())?;
+    let fut = del.prepare_proof(
+        &key,
+        &options,
+        &parents.iter().map(|p| p.as_ref()).collect::<Vec<&str>>(),
+    );
+    let result = throws!(cx, neon_serde::to_value(&mut cx, &rt.block_on(fut)))?;
+    Ok(result)
+}
+
+pub fn complete_delegate_capability(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let del = arg!(cx, 0, GenericDelegation);
+    let prep = arg!(cx, 1, ProofPreparation);
+    let sig = arg!(cx, 2, String);
+
+    let rt = throws!(cx, runtime::get())?;
+    let proof = rt.block_on(prep.complete(&sig));
+    let result = throws!(cx, neon_serde::to_value(&mut cx, del.set_proof(proof)))?;
+    Ok(result)
+}
+
+pub fn verify_delegation(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let del = arg!(cx, 0, GenericDelegation);
+    let options = arg!(cx, 1, LinkedDataProofOptions);
+
+    let rt = throws!(cx, runtime::get())?;
+    let fut = del.verify(options, DID_METHODS.to_resolver());
+    let result = throws!(cx, neon_serde::to_value(&mut cx, &rt.block_on(fut)))?;
+    Ok(result)
+}
+
+pub fn invoke_capability(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let inv = arg!(cx, 0, GenericInvocation);
+    let target = arg!(cx, 1, URI);
+    let options = arg!(cx, 2, LinkedDataProofOptions);
+    let key = arg!(cx, 3, JWK);
+
+    let rt = throws!(cx, runtime::get())?;
+    let fut = inv.generate_proof(&key, &options, &target);
+    let result = throws!(cx, neon_serde::to_value(&mut cx, &rt.block_on(fut)))?;
+    Ok(result)
+}
+
+pub fn prepare_invoke_capability(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let inv = arg!(cx, 0, GenericInvocation);
+    let target = arg!(cx, 1, URI);
+    let options = arg!(cx, 2, LinkedDataProofOptions);
+    let key = arg!(cx, 3, JWK);
+
+    let rt = throws!(cx, runtime::get())?;
+    let fut = inv.prepare_proof(&key, &options, &target);
+    let result = throws!(cx, neon_serde::to_value(&mut cx, &rt.block_on(fut)))?;
+    Ok(result)
+}
+
+pub fn complete_invoke_capability(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let inv = arg!(cx, 0, GenericInvocation);
+    let prep = arg!(cx, 1, ProofPreparation);
+    let sig = arg!(cx, 2, String);
+
+    let rt = throws!(cx, runtime::get())?;
+    let proof = rt.block_on(prep.complete(&sig));
+    let result = throws!(cx, neon_serde::to_value(&mut cx, inv.set_proof(proof)))?;
+    Ok(result)
+}
+
+pub fn verify_invocation(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let inv = arg!(cx, 0, GenericInvocation);
+    let del = arg!(cx, 1, GenericDelegation);
+    let options = arg!(cx, 2, LinkedDataProofOptions);
+
+    let rt = throws!(cx, runtime::get())?;
+    let fut = inv.verify(options, DID_METHODS.to_resolver(), del);
+    let result = throws!(cx, neon_serde::to_value(&mut cx, &rt.block_on(fut)))?;
+    Ok(result)
+}
+
+pub fn verify_invocation_signature(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let inv = arg!(cx, 0, GenericInvocation);
+    let options = arg!(cx, 1, LinkedDataProofOptions);
+
+    let rt = throws!(cx, runtime::get())?;
+    let fut = inv.verify_signature(options, DID_METHODS.to_resolver());
+    let result = throws!(cx, neon_serde::to_value(&mut cx, &rt.block_on(fut)))?;
     Ok(result)
 }

--- a/lib/node/src/didkit.rs
+++ b/lib/node/src/didkit.rs
@@ -168,6 +168,7 @@ pub fn delegate_capability(mut cx: FunctionContext) -> JsResult<JsValue> {
         rt.block_on(del.generate_proof(
             &key,
             &options,
+            DID_METHODS.to_resolver(),
             &parents.iter().map(|p| p.as_ref()).collect::<Vec<&str>>(),
         ))
     )?;
@@ -187,6 +188,7 @@ pub fn prepare_delegate_capability(mut cx: FunctionContext) -> JsResult<JsValue>
         rt.block_on(del.prepare_proof(
             &key,
             &options,
+            DID_METHODS.to_resolver(),
             &parents.iter().map(|p| p.as_ref()).collect::<Vec<&str>>(),
         ))
     )?;
@@ -222,7 +224,10 @@ pub fn invoke_capability(mut cx: FunctionContext) -> JsResult<JsValue> {
     let key = arg!(cx, 3, JWK);
 
     let rt = throws!(cx, runtime::get())?;
-    let proof = throws!(cx, rt.block_on(inv.generate_proof(&key, &options, &target)))?;
+    let proof = throws!(
+        cx,
+        rt.block_on(inv.generate_proof(&key, &options, DID_METHODS.to_resolver(), &target))
+    )?;
     let result = throws!(cx, neon_serde::to_value(&mut cx, &inv.set_proof(proof)))?;
     Ok(result)
 }
@@ -234,7 +239,10 @@ pub fn prepare_invoke_capability(mut cx: FunctionContext) -> JsResult<JsValue> {
     let key = arg!(cx, 3, JWK);
 
     let rt = throws!(cx, runtime::get())?;
-    let prep = throws!(cx, rt.block_on(inv.prepare_proof(&key, &options, &target)))?;
+    let prep = throws!(
+        cx,
+        rt.block_on(inv.prepare_proof(&key, &options, DID_METHODS.to_resolver(), &target))
+    )?;
     let result = throws!(cx, neon_serde::to_value(&mut cx, &prep))?;
     Ok(result)
 }

--- a/lib/node/src/lib.rs
+++ b/lib/node/src/lib.rs
@@ -21,5 +21,30 @@ register_module!(mut m, {
     m.export_function("verifyPresentation", didkit::verify_presentation)?;
     m.export_function("DIDAuth", didkit::did_auth)?;
 
+    m.export_function("delegateCapability", didkit::delegate_capability)?;
+    m.export_function(
+        "prepareDelegateCapability",
+        didkit::prepare_delegate_capability,
+    )?;
+    m.export_function(
+        "completeDelegateCapability",
+        didkit::complete_delegate_capability,
+    )?;
+
+    m.export_function("verifyDelegation", didkit::verify_delegation)?;
+
+    m.export_function("invokeCapability", didkit::invoke_capability)?;
+    m.export_function("prepareInvokeCapability", didkit::prepare_invoke_capability)?;
+    m.export_function(
+        "completeInvokeCapability",
+        didkit::complete_invoke_capability,
+    )?;
+
+    m.export_function("verifyInvocation", didkit::verify_invocation)?;
+    m.export_function(
+        "verifyInvocationSignature",
+        didkit::verify_invocation_signature,
+    )?;
+
     Ok(())
 });

--- a/lib/node/src/lib.rs
+++ b/lib/node/src/lib.rs
@@ -46,5 +46,7 @@ register_module!(mut m, {
         didkit::verify_invocation_signature,
     )?;
 
+    m.export_function("jwkFromTezosKey", didkit::jwk_from_tezos_key)?;
+
     Ok(())
 });

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -33,7 +33,7 @@ pub use ssi::vc::Presentation as VerifiablePresentation;
 pub use ssi::vc::ProofPurpose;
 pub use ssi::vc::VerificationResult;
 pub use ssi::vc::URI;
-pub use ssi::zcap::Delegation;
+pub use ssi::zcap::{Delegation, Invocation};
 
 use core::str::FromStr;
 use serde::{Deserialize, Serialize};

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -34,6 +34,7 @@ pub use ssi::vc::ProofPurpose;
 pub use ssi::vc::VerificationResult;
 pub use ssi::vc::URI;
 pub use ssi::zcap::{Delegation, Invocation};
+pub use ssi::tzkey::jwk_from_tezos_key;
 
 use core::str::FromStr;
 use serde::{Deserialize, Serialize};

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -33,6 +33,7 @@ pub use ssi::vc::Presentation as VerifiablePresentation;
 pub use ssi::vc::ProofPurpose;
 pub use ssi::vc::VerificationResult;
 pub use ssi::vc::URI;
+pub use ssi::zcap::Delegation;
 
 use core::str::FromStr;
 use serde::{Deserialize, Serialize};

--- a/lib/web/Cargo.toml
+++ b/lib/web/Cargo.toml
@@ -42,10 +42,13 @@ crate-type = ["cdylib"]
 wasm-opt = false
 
 [features]
-default = ["generate", "issue", "verify"]
+default = ["generate", "issue", "verify", "invoke", "delegate"]
 
 generate = []
 issue = []
 verify = []
 credential = []
 presentation = []
+delegate = []
+invoke = []
+zcap = []

--- a/lib/web/src/lib.rs
+++ b/lib/web/src/lib.rs
@@ -446,6 +446,7 @@ async fn delegate_capability(
         .generate_proof(
             &key,
             &options,
+            DID_METHODS.to_resolver(),
             &parents.iter().map(|p| p.as_ref()).collect::<Vec<&str>>(),
         )
         .await?;
@@ -484,6 +485,7 @@ async fn prepare_delegate_capability(
         .prepare_proof(
             &public_key,
             &options,
+            DID_METHODS.to_resolver(),
             &parents.iter().map(|p| p.as_ref()).collect::<Vec<&str>>(),
         )
         .await?;
@@ -561,7 +563,12 @@ async fn invoke_capability(
     let key: JWK = serde_json::from_str(&key)?;
     let options: LinkedDataProofOptions = serde_json::from_str(&linked_data_proof_options)?;
     let proof = invocation
-        .generate_proof(&key, &options, &URI::String(target_id))
+        .generate_proof(
+            &key,
+            &options,
+            DID_METHODS.to_resolver(),
+            &URI::String(target_id),
+        )
         .await?;
     let json = serde_json::to_string(&invocation.set_proof(proof))?;
     Ok(json)
@@ -594,7 +601,12 @@ async fn prepare_invoke_capability(
     let invocation: Invocation<Value> = serde_json::from_str(&invocation)?;
     let options: LinkedDataProofOptions = serde_json::from_str(&linked_data_proof_options)?;
     let preparation = invocation
-        .prepare_proof(&public_key, &options, &URI::String(target_id))
+        .prepare_proof(
+            &public_key,
+            &options,
+            DID_METHODS.to_resolver(),
+            &URI::String(target_id),
+        )
         .await?;
     let preparation_json = serde_json::to_string(&preparation)?;
     Ok(preparation_json)

--- a/lib/web/src/lib.rs
+++ b/lib/web/src/lib.rs
@@ -456,13 +456,8 @@ async fn delegate_capability(
 #[wasm_bindgen]
 #[allow(non_snake_case)]
 #[cfg(any(
-    all(feature = "issue", feature = "credential"),
-    all(feature = "issue", not(feature = "presentation")),
-    all(
-        feature = "credential",
-        not(feature = "issue"),
-        not(feature = "verify")
-    )
+    all(feature = "delegate", feature = "zcap"),
+    all(feature = "zcap", not(feature = "delegate"), not(feature = "invoke"))
 ))]
 pub fn delegateCapability(
     capability: String,
@@ -482,7 +477,7 @@ async fn prepare_delegate_capability(
     public_key: String,
 ) -> Result<String, Error> {
     let public_key: JWK = serde_json::from_str(&public_key)?;
-    let capability: Delegation<String, ()> = serde_json::from_str(&capability)?;
+    let capability: Delegation<String, Value> = serde_json::from_str(&capability)?;
     let options: LinkedDataProofOptions = serde_json::from_str(&linked_data_proof_options)?;
     let preparation = capability.prepare_proof(&public_key, &options).await?;
     let preparation_json = serde_json::to_string(&preparation)?;
@@ -491,7 +486,7 @@ async fn prepare_delegate_capability(
 
 #[wasm_bindgen]
 #[allow(non_snake_case)]
-#[cfg(feature = "issue")]
+#[cfg(feature = "delegate")]
 pub fn prepareDelegateCapability(
     capability: String,
     linked_data_proof_options: String,
@@ -509,7 +504,7 @@ async fn complete_delegate_capability(
     preparation: String,
     signature: String,
 ) -> Result<String, Error> {
-    let capability: Delegation<String, ()> = serde_json::from_str(&capability)?;
+    let capability: Delegation<String, Value> = serde_json::from_str(&capability)?;
     let preparation: ProofPreparation = serde_json::from_str(&preparation)?;
     let proof = preparation.complete(&signature).await?;
     let json = serde_json::to_string(&capability.set_proof(proof))?;
@@ -518,7 +513,7 @@ async fn complete_delegate_capability(
 
 #[wasm_bindgen]
 #[allow(non_snake_case)]
-#[cfg(feature = "issue")]
+#[cfg(feature = "delegate")]
 pub fn completeDelegateCapability(
     capability: String,
     preparation: String,
@@ -532,19 +527,14 @@ pub fn completeDelegateCapability(
 }
 
 #[cfg(any(
-    all(feature = "verify", feature = "credential"),
-    all(feature = "verify", not(feature = "presentation")),
-    all(
-        feature = "credential",
-        not(feature = "issue"),
-        not(feature = "verify")
-    )
+    all(feature = "delegate", feature = "zcap"),
+    all(feature = "zcap", not(feature = "delegate"), not(feature = "invoke"))
 ))]
 async fn verify_delegation(
     delegation: String,
     linked_data_proof_options: String,
 ) -> Result<String, Error> {
-    let delegation: Delegation<String, ()> = serde_json::from_str(&delegation)?;
+    let delegation: Delegation<String, Value> = serde_json::from_str(&delegation)?;
     let options: LinkedDataProofOptions = serde_json::from_str(&linked_data_proof_options)?;
     let result = delegation
         .verify(Some(options), DID_METHODS.to_resolver())
@@ -556,13 +546,8 @@ async fn verify_delegation(
 #[wasm_bindgen]
 #[allow(non_snake_case)]
 #[cfg(any(
-    all(feature = "verify", feature = "credential"),
-    all(feature = "verify", not(feature = "presentation")),
-    all(
-        feature = "credential",
-        not(feature = "issue"),
-        not(feature = "verify")
-    )
+    all(feature = "delegate", feature = "zcap"),
+    all(feature = "zcap", not(feature = "delegate"), not(feature = "invoke"))
 ))]
 pub fn verifyDelegation(delegation: String, linked_data_proof_options: String) -> Promise {
     map_async_jsvalue(verify_delegation(delegation, linked_data_proof_options))
@@ -595,13 +580,8 @@ async fn invoke_capability(
 #[wasm_bindgen]
 #[allow(non_snake_case)]
 #[cfg(any(
-    all(feature = "issue", feature = "credential"),
-    all(feature = "issue", not(feature = "presentation")),
-    all(
-        feature = "credential",
-        not(feature = "issue"),
-        not(feature = "verify")
-    )
+    all(feature = "invoke", feature = "zcap"),
+    all(feature = "zcap", not(feature = "delegate"), not(feature = "invoke"))
 ))]
 pub fn invokeCapability(
     invocation: String,
@@ -635,7 +615,7 @@ async fn prepare_invoke_capability(
 
 #[wasm_bindgen]
 #[allow(non_snake_case)]
-#[cfg(feature = "issue")]
+#[cfg(feature = "invoke")]
 pub fn prepareInvokeCapability(
     invocation: String,
     target_id: String,
@@ -664,7 +644,7 @@ async fn complete_invoke_capability(
 
 #[wasm_bindgen]
 #[allow(non_snake_case)]
-#[cfg(feature = "issue")]
+#[cfg(feature = "invoke")]
 pub fn completeInvokeCapability(
     invocation: String,
     preparation: String,

--- a/lib/web/src/lib.rs
+++ b/lib/web/src/lib.rs
@@ -438,7 +438,7 @@ async fn delegate_capability(
     parent_caps: String,
     key: String,
 ) -> Result<String, Error> {
-    let delegation: Delegation<String, Value> = serde_json::from_str(&capability)?;
+    let delegation: Delegation<Value, Value> = serde_json::from_str(&capability)?;
     let key: JWK = serde_json::from_str(&key)?;
     let options: LinkedDataProofOptions = serde_json::from_str(&linked_data_proof_options)?;
     let parents: Vec<String> = serde_json::from_str(&parent_caps)?;
@@ -477,7 +477,7 @@ async fn prepare_delegate_capability(
     public_key: String,
 ) -> Result<String, Error> {
     let public_key: JWK = serde_json::from_str(&public_key)?;
-    let capability: Delegation<String, Value> = serde_json::from_str(&capability)?;
+    let capability: Delegation<Value, Value> = serde_json::from_str(&capability)?;
     let options: LinkedDataProofOptions = serde_json::from_str(&linked_data_proof_options)?;
     let parents: Vec<String> = serde_json::from_str(&parent_caps)?;
     let preparation = capability
@@ -513,7 +513,7 @@ async fn complete_delegate_capability(
     preparation: String,
     signature: String,
 ) -> Result<String, Error> {
-    let capability: Delegation<String, Value> = serde_json::from_str(&capability)?;
+    let capability: Delegation<Value, Value> = serde_json::from_str(&capability)?;
     let preparation: ProofPreparation = serde_json::from_str(&preparation)?;
     let proof = preparation.complete(&signature).await?;
     let json = serde_json::to_string(&capability.set_proof(proof))?;
@@ -535,12 +535,12 @@ pub fn completeDelegateCapability(
     ))
 }
 
-#[cfg(any(all(feature = "delegate", feature = "zcap", feature = "invoke")))]
+#[cfg(any(feature = "delegate", feature = "zcap", feature = "invoke"))]
 async fn verify_delegation(
     delegation: String,
     linked_data_proof_options: String,
 ) -> Result<String, Error> {
-    let delegation: Delegation<String, Value> = serde_json::from_str(&delegation)?;
+    let delegation: Delegation<Value, Value> = serde_json::from_str(&delegation)?;
     let options: LinkedDataProofOptions = serde_json::from_str(&linked_data_proof_options)?;
     let result = delegation
         .verify(Some(options), DID_METHODS.to_resolver())
@@ -551,19 +551,19 @@ async fn verify_delegation(
 
 #[wasm_bindgen]
 #[allow(non_snake_case)]
-#[cfg(any(all(feature = "delegate", feature = "zcap", feature = "invoke")))]
+#[cfg(any(feature = "delegate", feature = "zcap", feature = "invoke"))]
 pub fn verifyDelegation(delegation: String, linked_data_proof_options: String) -> Promise {
     map_async_jsvalue(verify_delegation(delegation, linked_data_proof_options))
 }
 
-#[cfg(any(all(feature = "invoke", feature = "zcap")))]
+#[cfg(any(feature = "invoke", feature = "zcap"))]
 async fn invoke_capability(
     invocation: String,
     target_id: String,
     linked_data_proof_options: String,
     key: String,
 ) -> Result<String, Error> {
-    let invocation: Invocation<String> = serde_json::from_str(&invocation)?;
+    let invocation: Invocation<Value> = serde_json::from_str(&invocation)?;
     let key: JWK = serde_json::from_str(&key)?;
     let options: LinkedDataProofOptions = serde_json::from_str(&linked_data_proof_options)?;
     let proof = invocation
@@ -575,7 +575,7 @@ async fn invoke_capability(
 
 #[wasm_bindgen]
 #[allow(non_snake_case)]
-#[cfg(any(all(feature = "invoke", feature = "zcap")))]
+#[cfg(any(feature = "invoke", feature = "zcap"))]
 pub fn invokeCapability(
     invocation: String,
     target_id: String,
@@ -597,7 +597,7 @@ async fn prepare_invoke_capability(
     public_key: String,
 ) -> Result<String, Error> {
     let public_key: JWK = serde_json::from_str(&public_key)?;
-    let invocation: Invocation<String> = serde_json::from_str(&invocation)?;
+    let invocation: Invocation<Value> = serde_json::from_str(&invocation)?;
     let options: LinkedDataProofOptions = serde_json::from_str(&linked_data_proof_options)?;
     let preparation = invocation
         .prepare_proof(&public_key, &options, &URI::String(target_id))
@@ -608,7 +608,7 @@ async fn prepare_invoke_capability(
 
 #[wasm_bindgen]
 #[allow(non_snake_case)]
-#[cfg(any(all(feature = "invoke", feature = "zcap")))]
+#[cfg(any(feature = "invoke", feature = "zcap"))]
 pub fn prepareInvokeCapability(
     invocation: String,
     target_id: String,
@@ -628,7 +628,7 @@ async fn complete_invoke_capability(
     preparation: String,
     signature: String,
 ) -> Result<String, Error> {
-    let invocation: Invocation<String> = serde_json::from_str(&invocation)?;
+    let invocation: Invocation<Value> = serde_json::from_str(&invocation)?;
     let preparation: ProofPreparation = serde_json::from_str(&preparation)?;
     let proof = preparation.complete(&signature).await?;
     let json = serde_json::to_string(&invocation.set_proof(proof))?;
@@ -637,7 +637,7 @@ async fn complete_invoke_capability(
 
 #[wasm_bindgen]
 #[allow(non_snake_case)]
-#[cfg(any(all(feature = "invoke", feature = "zcap")))]
+#[cfg(any(feature = "invoke", feature = "zcap"))]
 pub fn completeInvokeCapability(
     invocation: String,
     preparation: String,
@@ -650,7 +650,7 @@ pub fn completeInvokeCapability(
     ))
 }
 
-#[cfg(any(all(feature = "invoke", feature = "zcap")))]
+#[cfg(any(feature = "invoke", feature = "zcap"))]
 async fn verify_invocation_signature(
     invocation: String,
     linked_data_proof_options: String,
@@ -666,28 +666,25 @@ async fn verify_invocation_signature(
 
 #[wasm_bindgen]
 #[allow(non_snake_case)]
-#[cfg(any(all(feature = "invoke", feature = "zcap")))]
-pub fn verifyInvocation_signature(
-    invocation: String,
-    linked_data_proof_options: String,
-) -> Promise {
+#[cfg(any(feature = "invoke", feature = "zcap"))]
+pub fn verifyInvocationSignature(invocation: String, linked_data_proof_options: String) -> Promise {
     map_async_jsvalue(verify_invocation_signature(
         invocation,
         linked_data_proof_options,
     ))
 }
 
-#[cfg(any(all(feature = "invoke", feature = "zcap")))]
+#[cfg(any(feature = "invoke", feature = "zcap"))]
 async fn verify_invocation(
     invocation: String,
     delegation: String,
     linked_data_proof_options: String,
 ) -> Result<String, Error> {
     let invocation: Invocation<Value> = serde_json::from_str(&invocation)?;
-    let delegation: Delegation<String, Value> = serde_json::from_str(&delegation)?;
+    let delegation: Delegation<Value, Value> = serde_json::from_str(&delegation)?;
     let options: LinkedDataProofOptions = serde_json::from_str(&linked_data_proof_options)?;
     let result = invocation
-        .verify(Some(options), DID_METHODS.to_resolver(), delegation)
+        .verify(Some(options), DID_METHODS.to_resolver(), &delegation)
         .await;
     let result_json = serde_json::to_string(&result)?;
     Ok(result_json)
@@ -695,7 +692,7 @@ async fn verify_invocation(
 
 #[wasm_bindgen]
 #[allow(non_snake_case)]
-#[cfg(any(all(feature = "invoke", feature = "zcap")))]
+#[cfg(any(feature = "invoke", feature = "zcap"))]
 pub fn verifyInvocation(
     invocation: String,
     delegation: String,

--- a/lib/web/src/lib.rs
+++ b/lib/web/src/lib.rs
@@ -536,15 +536,9 @@ pub fn completeDelegateCapability(
 }
 
 #[cfg(any(feature = "delegate", feature = "zcap", feature = "invoke"))]
-async fn verify_delegation(
-    delegation: String,
-    linked_data_proof_options: String,
-) -> Result<String, Error> {
+async fn verify_delegation(delegation: String) -> Result<String, Error> {
     let delegation: Delegation<Value, Value> = serde_json::from_str(&delegation)?;
-    let options: LinkedDataProofOptions = serde_json::from_str(&linked_data_proof_options)?;
-    let result = delegation
-        .verify(Some(options), DID_METHODS.to_resolver())
-        .await;
+    let result = delegation.verify(None, DID_METHODS.to_resolver()).await;
     let result_json = serde_json::to_string(&result)?;
     Ok(result_json)
 }
@@ -552,8 +546,8 @@ async fn verify_delegation(
 #[wasm_bindgen]
 #[allow(non_snake_case)]
 #[cfg(any(feature = "delegate", feature = "zcap", feature = "invoke"))]
-pub fn verifyDelegation(delegation: String, linked_data_proof_options: String) -> Promise {
-    map_async_jsvalue(verify_delegation(delegation, linked_data_proof_options))
+pub fn verifyDelegation(delegation: String) -> Promise {
+    map_async_jsvalue(verify_delegation(delegation))
 }
 
 #[cfg(any(feature = "invoke", feature = "zcap"))]
@@ -651,14 +645,10 @@ pub fn completeInvokeCapability(
 }
 
 #[cfg(any(feature = "invoke", feature = "zcap"))]
-async fn verify_invocation_signature(
-    invocation: String,
-    linked_data_proof_options: String,
-) -> Result<String, Error> {
+async fn verify_invocation_signature(invocation: String) -> Result<String, Error> {
     let invocation: Invocation<Value> = serde_json::from_str(&invocation)?;
-    let options: LinkedDataProofOptions = serde_json::from_str(&linked_data_proof_options)?;
     let result = invocation
-        .verify_signature(Some(options), DID_METHODS.to_resolver())
+        .verify_signature(None, DID_METHODS.to_resolver())
         .await;
     let result_json = serde_json::to_string(&result)?;
     Ok(result_json)
@@ -667,24 +657,16 @@ async fn verify_invocation_signature(
 #[wasm_bindgen]
 #[allow(non_snake_case)]
 #[cfg(any(feature = "invoke", feature = "zcap"))]
-pub fn verifyInvocationSignature(invocation: String, linked_data_proof_options: String) -> Promise {
-    map_async_jsvalue(verify_invocation_signature(
-        invocation,
-        linked_data_proof_options,
-    ))
+pub fn verifyInvocationSignature(invocation: String) -> Promise {
+    map_async_jsvalue(verify_invocation_signature(invocation))
 }
 
 #[cfg(any(feature = "invoke", feature = "zcap"))]
-async fn verify_invocation(
-    invocation: String,
-    delegation: String,
-    linked_data_proof_options: String,
-) -> Result<String, Error> {
+async fn verify_invocation(invocation: String, delegation: String) -> Result<String, Error> {
     let invocation: Invocation<Value> = serde_json::from_str(&invocation)?;
     let delegation: Delegation<Value, Value> = serde_json::from_str(&delegation)?;
-    let options: LinkedDataProofOptions = serde_json::from_str(&linked_data_proof_options)?;
     let result = invocation
-        .verify(Some(options), DID_METHODS.to_resolver(), &delegation)
+        .verify(None, DID_METHODS.to_resolver(), &delegation)
         .await;
     let result_json = serde_json::to_string(&result)?;
     Ok(result_json)
@@ -693,14 +675,6 @@ async fn verify_invocation(
 #[wasm_bindgen]
 #[allow(non_snake_case)]
 #[cfg(any(feature = "invoke", feature = "zcap"))]
-pub fn verifyInvocation(
-    invocation: String,
-    delegation: String,
-    linked_data_proof_options: String,
-) -> Promise {
-    map_async_jsvalue(verify_invocation(
-        invocation,
-        delegation,
-        linked_data_proof_options,
-    ))
+pub fn verifyInvocation(invocation: String, delegation: String) -> Promise {
+    map_async_jsvalue(verify_invocation(invocation, delegation))
 }


### PR DESCRIPTION
Exposes ZCAP-LD functionality in `didkit`, `didkit-wasm` and `@spruceid/didkit` using a similar pattern to the VC interface.
Feature flag `delegate`:
- `delegateCapability`
- `prepareDelegateCapability`
- `completeDelegateCapability`
- `verifyDelegation`

Feature flag `invoke`:
- `invokeCapability`
- `prepareInvokeCapability`
- `completeInvokeCapability`
- `verifyInvocationSignature`
- `verifyInvocation`

Feature flag `zcap` enables all functions.