### PR TITLE
Update `lombok` dependency in Java JSP example

### DIFF
--- a/examples/java-jsp/pom.xml
+++ b/examples/java-jsp/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.16</version>
+            <version>1.18.20</version>
         </dependency>
         <dependency>
             <groupId>com.spruceid.didkit</groupId>


### PR DESCRIPTION
Updates `lombok` version in Java JSP example to prevent `IllegalAccessError` on newer Java versions.