### PR TITLE
Remove plugfest-2020 VC HTTP API Test Suite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,19 +101,6 @@ jobs:
     - name: Test binary-signing verify example
       run: examples/binary-signing/index.sh verify examples/binary-signing/hello.txt examples/binary-signing/hello-vc.jsonld
 
-    - name: Checkout vc-http-api v0.0.1
-      uses: actions/checkout@v2
-      with:
-        repository: spruceid/vc-http-api
-        path: vc-http-api
-        ref: eef5ef2bb2321e4eac3f7e82a2adb7ccd4db1982
-
-    - name: Run vc-http-api plugfest-2020 test suite
-      working-directory: vc-http-api/packages/plugfest-2020
-      run: |
-        npm i
-        ./vendors/spruce/test.sh
-
     - name: Checkout VC HTTP API Test Suite
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Everything tested in the VC HTTP API v0.0.1 Test Suite (Plugfest 2020) should be covered by the newer VC HTTP API Test Suite - but the old one might not be updated anymore.