### PR TITLE
didkit v0.3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         repository: spruceid/ssi
         path: ssi
-        ref: 21c13cc96a28c36fa6d1cb8407fc235035fb9f6d
+        ref: c66972290377c6b4bf9b63b2dfdc047dbdcfd989
         submodules: true
 
     - name: Cache Cargo registry and build artifacts
@@ -180,7 +180,7 @@ jobs:
       with:
         repository: spruceid/ssi
         path: ssi
-        ref: 21c13cc96a28c36fa6d1cb8407fc235035fb9f6d
+        ref: c66972290377c6b4bf9b63b2dfdc047dbdcfd989
         submodules: true
 
     - name: Cache Cargo registry and build artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
       with:
         repository: w3c-ccg/vc-http-api-test-suite
         path: didkit/http/tests/vc-http-api/vc-http-api-test-suite
-        ref: 61d498cd04c45a22b9578774e6a066b59a8f4e94
+        ref: 163603de2d36289f5220029fd1ed410a969bd057
 
     - name: Run VC HTTP API Test Suite
       working-directory: didkit/http/tests/vc-http-api

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Removed Android AAR Make target (`target/test/android.stamp`).
+- Removed `did:sol` implementation until it can be made conformant with specification.
 
 ### Fixed
 - Fix various build errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Publish AAR package to GitHub.
 - Rename functions in Python package to use snake-case.
 - Update for interface changes in `ssi`.
+- Update to use `ssi v0.3`
 
 ### Deprecated
 - Deprecated camelCase functions in Python package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.0] - 2021-09-17
 ### Added
 - Issue and verify JWT [VCs][vc-data-model] and [VPs][Verifiable Presentations].
 - Implement signing using `ssh-agent`.
@@ -30,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Removed Android AAR Make target (`target/test/android.stamp`).
 - Removed `did:sol` implementation until it can be made conformant with specification.
+- Remove ASM.js library.
 
 ### Fixed
 - Fix various build errors.
@@ -121,7 +124,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [wasm-pack]: https://rustwasm.github.io/wasm-pack/
 [zcap-ld]: https://w3c-ccg.github.io/zcap-ld/
 
-[Unreleased]: https://github.com/spruceid/didkit/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/spruceid/didkit/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/spruceid/didkit/releases/tag/v0.3.0
 [0.2.1]: https://github.com/spruceid/didkit/releases/tag/v0.2.1
 [0.2.0]: https://github.com/spruceid/didkit/releases/tag/v0.2.0
 [0.1.0]: https://github.com/spruceid/didkit/releases/tag/v0.1.0

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 structopt = "0.3"
 did-method-key = { version = "0.1", path = "../../ssi/did-key" }
-ssi = { version = "0.2", path = "../../ssi", default-features = false }
+ssi = { version = "0.3", path = "../../ssi", default-features = false }
 thiserror = "1.0"
 bytes = "1.0"
 base64 = "0.12"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,7 +23,7 @@ ring = ["ssi/ring"]
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-didkit = { version = "0.2", path = "../lib", features = ["http-did"] }
+didkit = { version = "0.3", path = "../lib", features = ["http-did"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 structopt = "0.3"

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -31,7 +31,7 @@ serde_urlencoded = "0.7"
 hyper = { version = "0.14", features = ["server", "client", "http1", "http2", "stream"] }
 tower-service = "0.3"
 futures-util = { version = "0.3", default-features = false }
-ssi = { version = "0.2", path = "../../ssi", default-features = false }
+ssi = { version = "0.3", path = "../../ssi", default-features = false }
 percent-encoding = "2.1"
 
 [dev-dependencies]

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -21,7 +21,7 @@ default = ["ring"]
 ring = ["ssi/ring"]
 
 [dependencies]
-didkit = { version = "0.2", path = "../lib", features = ["http-did"] }
+didkit = { version = "0.3", path = "../lib", features = ["http-did"] }
 didkit-cli = { version = "0.1", path = "../cli" }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 structopt = "0.3"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didkit"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 description = "Library for Verifiable Credentials and Decentralized Identifiers."

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -33,7 +33,7 @@ did-method-key = { version = "0.1", path = "../../ssi/did-key" }
 did-tz = { version = "0.1", path = "../../ssi/did-tezos", default-features = false }
 did-ethr = { version = "0.0.1", path = "../../ssi/did-ethr" }
 did-pkh = { version = "0.0.1", path = "../../ssi/did-pkh" }
-did-sol = { version = "0.0.1", path = "../../ssi/did-sol" }
+#did-sol = { version = "0.0.1", path = "../../ssi/did-sol" }
 did-web = { version = "0.1", path = "../../ssi/did-web" }
 did-webkey = { version = "0.1", path = "../../ssi/did-webkey" }
 did-onion = { version = "0.1", path = "../../ssi/did-onion" }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -27,16 +27,15 @@ secp256k1 = ["ssi/libsecp256k1", "did-tz/secp256k1", "did-method-key/secp256k1"]
 p256 = ["ssi/secp256r1", "did-tz/p256", "did-webkey/p256", "did-method-key/secp256r1"]
 
 [dependencies]
-didkit-cbindings = { path = "cbindings/" }
-ssi = { version = "0.2", path = "../../ssi", default-features = false }
-did-method-key = { version = "0.1", path = "../../ssi/did-key" }
-did-tz = { version = "0.1", path = "../../ssi/did-tezos", default-features = false }
-did-ethr = { version = "0.0.1", path = "../../ssi/did-ethr" }
-did-pkh = { version = "0.0.1", path = "../../ssi/did-pkh" }
+ssi = { version = "0.3", path = "../../ssi", default-features = false }
+did-method-key = { version = "^0.1.2", path = "../../ssi/did-key" }
+did-tz = { version = "^0.1.1", path = "../../ssi/did-tezos", default-features = false }
+did-ethr = { version = "0.1", path = "../../ssi/did-ethr" }
+did-pkh = { version = "0.1", path = "../../ssi/did-pkh" }
 #did-sol = { version = "0.0.1", path = "../../ssi/did-sol" }
-did-web = { version = "0.1", path = "../../ssi/did-web" }
+did-web = { version = "^0.1.1", path = "../../ssi/did-web" }
 did-webkey = { version = "0.1", path = "../../ssi/did-webkey" }
-did-onion = { version = "0.1", path = "../../ssi/did-onion" }
+did-onion = { version = "^0.1.1", path = "../../ssi/did-onion" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 jni = "0.17"

--- a/lib/node/Cargo.toml
+++ b/lib/node/Cargo.toml
@@ -16,7 +16,7 @@ serde = "1.0"
 serde_json = "1.0"
 
 [dependencies.ssi]
-version = "0.2.1"
+version = "0.3"
 path = "../../../ssi"
 
 [dependencies.didkit]

--- a/lib/node/Cargo.toml
+++ b/lib/node/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.3"
 path = "../../../ssi"
 
 [dependencies.didkit]
-version = "0.2.1"
+version = "0.3"
 default-features = false
 path = "../"
 

--- a/lib/python/setup.cfg
+++ b/lib/python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = didkit
-version = 0.2.2
+version = 0.3.0
 author = Spruce Systems, Inc.
 author_email = oss@spruceid.com
 description = DIDKit python package

--- a/lib/src/did_methods.rs
+++ b/lib/src/did_methods.rs
@@ -2,7 +2,7 @@ use did_ethr::DIDEthr;
 use did_method_key::DIDKey;
 use did_onion::DIDOnion;
 use did_pkh::DIDPKH;
-use did_sol::DIDSol;
+// use did_sol::DIDSol;
 use did_tz::DIDTz;
 use did_web::DIDWeb;
 use did_webkey::DIDWebKey;
@@ -16,7 +16,7 @@ lazy_static! {
         methods.insert(&DIDKey);
         methods.insert(&*DIDTZ);
         methods.insert(&DIDEthr);
-        methods.insert(&DIDSol);
+        // methods.insert(&DIDSol);
         methods.insert(&DIDWeb);
         methods.insert(&DIDWebKey);
         methods.insert(&DIDPKH);


### PR DESCRIPTION
- Update to use ssi v0.3 (https://github.com/spruceid/ssi/pull/296)
- Use VC HTTP API Test Suite with regenerated VP case 2 (https://github.com/w3c-ccg/vc-http-api-test-suite/pull/3)
- Disable `did-sol` until it can be updated to conform with the registered [did:sol specification](https://identity-com.github.io/sol-did/did-method-spec.html)
- Prepare `didkit`~~, `didkit-cli` and `didkit-http` crates~~ for publishing to `crates.io`