### PR TITLE
Add description for method-pattern CLI argument

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -31,12 +31,14 @@ pub enum DIDKit {
     },
     /// Output a DID for a given JWK and DID method name or pattern.
     KeyToDID {
+        /// DID method id or pattern. e.g. `key`, `tz`, or `pkh:tz`
         method_pattern: String,
         #[structopt(flatten)]
         key: KeyArg,
     },
     /// Output a verificationMethod DID URL for a JWK and DID method name/pattern
     KeyToVerificationMethod {
+        /// DID method id or pattern. e.g. `key`, `tz`, or `pkh:tz`
         method_pattern: Option<String>,
         #[structopt(flatten)]
         key: KeyArg,


### PR DESCRIPTION
As mentioned in https://github.com/spruceid/didkit/issues/213#issuecomment-918570842

Add brief description and example values for the "method-pattern" parameter
of the DIDKit CLI subcommands `key-to-did` and `key-to-verification-method`.

Help text for `key-to-did` would now appear as follows:
```
$ didkit key-to-did --help
didkit-key-to-did 0.1.1
Output a DID for a given JWK and DID method name or pattern

USAGE:
    didkit key-to-did [OPTIONS] <method-pattern> <--key-path <key-path>|--jwk <jwk>|--ssh-agent>

FLAGS:
    -h, --help         Prints help information
    -S, --ssh-agent    Request signature using SSH Agent
    -V, --version      Prints version information

OPTIONS:
    -j, --jwk <jwk>              WARNING: you should not use this through the CLI in a production environment, prefer
                                 its environment variable. [env: JWK]
    -k, --key-path <key-path>     [env: KEY_PATH=]

ARGS:
    <method-pattern>    DID method id or pattern. e.g. `key`, `tz`, or `pkh:tz`
```