### PR TITLE
Trim whitespace off of JWT that may have been added by a text editor.

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -458,6 +458,8 @@ fn main() {
                 ProofFormat::JWT => {
                     let mut jwt = String::new();
                     credential_reader.read_to_string(&mut jwt).unwrap();
+                    // Trim off whitespace that may have been added by a text editor.
+                    jwt = jwt.trim().to_string();
                     rt.block_on(VerifiableCredential::verify_jwt(
                         &jwt,
                         Some(options),
@@ -543,6 +545,8 @@ fn main() {
                 ProofFormat::JWT => {
                     let mut jwt = String::new();
                     presentation_reader.read_to_string(&mut jwt).unwrap();
+                    // Trim off whitespace that may have been added by a text editor.
+                    jwt = jwt.trim().to_string();
                     rt.block_on(VerifiablePresentation::verify_jwt(
                         &jwt,
                         Some(options),


### PR DESCRIPTION
This is a usability improvement.  See https://github.com/spruceid/didkit/issues/212