### PR TITLE
DIDKit CLI and HTTP v0.1.1

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didkit-cli"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 description = "Command-line interface for Verifiable Credentials and Decentralized Identifiers."

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didkit-http"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 description = "HTTP server for Verifiable Credentials and Decentralized Identifiers."
@@ -22,7 +22,7 @@ ring = ["ssi/ring"]
 
 [dependencies]
 didkit = { version = "0.3", path = "../lib", features = ["http-did"] }
-didkit-cli = { version = "0.1", path = "../cli" }
+didkit-cli = { version = "^0.1.1", path = "../cli" }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 structopt = "0.3"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Publish `didkit-cli` and `didkit-http` crates to `crates.io`, using `didkit v0.3.0` (#216).