### PR TITLE
Fix flutter jniLibs symbolic links

### DIFF
--- a/lib/flutter/android/src/main/jniLibs/arm64-v8a/libdidkit.so
+++ b/lib/flutter/android/src/main/jniLibs/arm64-v8a/libdidkit.so
@@ -1,1 +1,1 @@
-../../../../android/jni/arm64-v8a/libdidkit.so
+../../../../../../android/didkit/src/main/jniLibs/arm64-v8a/libdidkit.so

--- a/lib/flutter/android/src/main/jniLibs/armeabi-v7a/libdidkit.so
+++ b/lib/flutter/android/src/main/jniLibs/armeabi-v7a/libdidkit.so
@@ -1,1 +1,1 @@
-../../../../android/jni/armeabi-v7a/libdidkit.so
+../../../../../../android/didkit/src/main/jniLibs/armeabi-v7a/libdidkit.so

--- a/lib/flutter/android/src/main/jniLibs/x86_64/libdidkit.so
+++ b/lib/flutter/android/src/main/jniLibs/x86_64/libdidkit.so
@@ -1,1 +1,1 @@
-../../../../android/jni/x86_64/libdidkit.so
+../../../../../../android/didkit/src/main/jniLibs/x86_64/libdidkit.so

--- a/lib/flutter/example/ios/Flutter/Debug.xcconfig
+++ b/lib/flutter/example/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/lib/flutter/example/ios/Flutter/Release.xcconfig
+++ b/lib/flutter/example/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/lib/flutter/example/ios/Podfile
+++ b/lib/flutter/example/ios/Podfile
@@ -1,0 +1,41 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/lib/flutter/example/pubspec.lock
+++ b/lib/flutter/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -87,14 +87,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -120,7 +120,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -155,7 +155,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## Description

The `libdidkit.so` symlinks on the flutter android lib were pointing to the wrong path.
The final apk generated by an app that embeds didkit flutter library was generated without the needed static libraries.

Fixes spruceid/credible#89