### PR TITLE
Add CLI proof type option

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -64,6 +64,7 @@ One of `-k` (`--key-path`), `-j` (`--jwk`) or `-S` (`--ssh-agent`) is required.
 
 The following options correspond to linked data [proof options][] as specified in [ld-proofs][] and [vc-http-api][]:
 
+- `-t, --type <type>` - `type` of proof object to create.
 - `-C, --challenge <challenge>` - [challenge][] property of the proof
 - `-c, --created <created>` - [created][] property of the proof. ISO8601 datetime. Defaults to the current time.
   time.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -164,6 +164,8 @@ pub enum DIDKit {
 pub struct ProofOptions {
     // Options as in vc-http-api
     #[structopt(env, short, long)]
+    pub type_: Option<String>,
+    #[structopt(env, short, long)]
     pub verification_method: Option<URI>,
     #[structopt(env, short, long)]
     pub proof_purpose: Option<ProofPurpose>,
@@ -220,6 +222,7 @@ impl KeyArg {
 impl From<ProofOptions> for LinkedDataProofOptions {
     fn from(options: ProofOptions) -> LinkedDataProofOptions {
         LinkedDataProofOptions {
+            type_: options.type_,
             verification_method: options.verification_method,
             proof_purpose: options.proof_purpose,
             created: options.created,


### PR DESCRIPTION
Some key types may be used with multiple linked data proof types. Add a `-t` (`--type`) to override the default type when issuing a verifiable credential/presentation.
With https://github.com/spruceid/ssi/pull/329 this can also be used to select specific proof types for credential/presentation verification.