### PR TITLE
Document DIDKit HTTP security considerations

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -70,6 +70,16 @@ The following route implements the [DID Resolution HTTP(S) Binding][did-http].
 
 Resolve a DID to a DID document, or dereference a DID URL to a resource. Parameter `<uri>` is the DID or DID URL to resolve/dereference.
 
+## Security Considerations
+
+### Authorization
+
+DIDKit HTTP does not implement any endpoint authorization or access control. Any client can request a signature/proof creation from the server's key(s) using the issue credential/presentation endpoints. To limit access to some or all of DIDKit HTTP's endpoints, a deployment should place DIDKit HTTP behind a reverse proxy with appropriate settings.
+
+### Denial of Service
+
+DIDKit HTTP does not implement protection against resource exhaustion. Clients may be able to overwhelm the server with excessively large, slow, and/or concurrent requests. To protect against resource exhaustion, deployments should use a reverse proxy with rate limiting, request payload size limiting, load balancing across multiple DIDKit HTTP instances, and/or other protections.
+
 [did-http]: https://w3c-ccg.github.io/did-resolution/#bindings-https
 [vc-http-api]: https://w3c-ccg.github.io/vc-http-api/
 [vc-http-api-0.0.1]: https://github.com/w3c-ccg/vc-http-api/pull/72

--- a/http/README.md
+++ b/http/README.md
@@ -46,6 +46,12 @@ library. Struct `didkit_http::DIDKitHTTPMakeSvc` implements a Tower
 
 The following routes implement [W3C CCG's VC HTTP API (vc-http-api)][vc-http-api] [v0.0.1][vc-http-api-0.0.1]. POST bodies should be `application/json`. Output will be `application/json` on success; on error it will be either `application/json` or plain text. For more details, see `vc-http-api`.
 
+#### Limits
+
+#### Maximum payload size
+
+DIDKit HTTP's POST endpoints implement a request payload maximum size of 2MB, to protect against resource exhaustion due to excessively large payloads. This limit is in a constant, `MAX_BODY_LENGTH`, but in the future might be made configurable: https://github.com/spruceid/didkit/issues/236.
+
 #### POST `/credentials/issue`
 
 Issue a verifiable credential. The server uses its configured key and the given linked data proof options to generate a proof and append it to the given credential. On success, the resulting verifiable credential is returned, with HTTP status 201.
@@ -80,7 +86,7 @@ DIDKit HTTP does not implement any endpoint authorization or access control. Any
 
 ### Denial of Service
 
-DIDKit HTTP does not implement protection against resource exhaustion. Clients may be able to overwhelm the server with excessively large, slow, and/or concurrent requests. To protect against resource exhaustion, deployments should use a reverse proxy with rate limiting, request payload size limiting, load balancing across multiple DIDKit HTTP instances, and/or other protections.
+DIDKit HTTP does not implement complete protection against resource exhaustion. Clients may be able to overwhelm the server with excessively slow and/or concurrent requests. To protect against resource exhaustion, deployments should use a reverse proxy with rate limiting, load balancing across multiple DIDKit HTTP instances, and/or other protections.
 
 [did-http]: https://w3c-ccg.github.io/did-resolution/#bindings-https
 [vc-http-api]: https://w3c-ccg.github.io/vc-http-api/

--- a/http/README.md
+++ b/http/README.md
@@ -72,6 +72,8 @@ Resolve a DID to a DID document, or dereference a DID URL to a resource. Paramet
 
 ## Security Considerations
 
+Spruce does not use DIDKit HTTP in any production environments except with a reverse proxy, and does not recommend them for production use-cases without a holistic review of security levels.  The following is not an exhaustive list, but should be considered in any such review.
+
 ### Authorization
 
 DIDKit HTTP does not implement any endpoint authorization or access control. Any client can request a signature/proof creation from the server's key(s) using the issue credential/presentation endpoints. To limit access to some or all of DIDKit HTTP's endpoints, a deployment should place DIDKit HTTP behind a reverse proxy with appropriate settings.


### PR DESCRIPTION
This is to note that DIDKit HTTP assumes a trusted environment, and that certain security considerations should be addressed in deployments.