### PR TITLE
Fix Prove Presentation endpoint

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -54,7 +54,7 @@ Issue a verifiable credential. The server uses its configured key and the given 
 
 Verify a verifiable credential. The server verifies the given credential with the given linked data proof options. To successfully verify, the credential must contain at least one proof that verifies successfully. Verification results include a list of checks performed, warnings that should be flagged to the user, and errors encountered. On success, the errors list will be empty, and the HTTP status code will be 200.
 
-#### POST `/credentials/prove`
+#### POST `/presentations/prove`
 
 Create a verifiable presentation. Given a presentation and linked data proof options, the server uses its key to generate a proof and append it to the presentation. On success, returns the verifiable presentation and HTTP status 201.
 

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -657,10 +657,13 @@ impl Service<Request<Body>> for DIDKitHTTPSvc {
             "/verify/credentials" => return self.verify_credentials(req),
             "/prove/presentations" => return self.prove_presentations(req),
             "/verify/presentations" => return self.verify_presentations(req),
-            // vc-http-api 0.0.2-unstable
+            // vc-http-api 0.0.2-unstable - https://w3c-ccg.github.io/vc-api/versions/v0.0.2/
             "/credentials/issue" => return self.issue_credentials(req),
             "/credentials/verify" => return self.verify_credentials(req),
+            // /credentials/prove is a mistake (should be /presentations/prove) but leaving in
+            // for backwards-compatibility.
             "/credentials/prove" => return self.prove_presentations(req),
+            "/presentations/prove" => return self.prove_presentations(req),
             "/presentations/verify" => return self.verify_presentations(req),
             _ => {}
         };


### PR DESCRIPTION
The [prove presentation](https://w3c-ccg.github.io/vc-api/#prove-presentation) endpoint was given as `/credentials/prove`, but it should be `/presentations/prove`. This PR adds support for the correct endpoint, leaving the old one in for compatibiltity purposes, and updates the documentation to refer to the correct endpoint.