### PR TITLE
Update key-to-did

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -32,6 +32,7 @@ pub enum DIDKit {
     /// Output a DID for a given JWK and DID method name or pattern.
     KeyToDID {
         /// DID method id or pattern. e.g. `key`, `tz`, or `pkh:tz`
+        #[structopt(default_value = "key")]
         method_pattern: String,
         #[structopt(flatten)]
         key: KeyArg,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -35,7 +35,7 @@ pub enum DIDKit {
     /// that support this functionality.
     ///
     /// The DID method to use may be provided in the `method-pattern` argument. The default is
-    /// `did:key`.
+    /// "key", corresponding to did:key.
     ///
     /// For DID methods that have multiple ways of representing a key, `method-pattern` is
     /// method-specific but typically is a prefix, for example "pkh:tz" to generate a DID that

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -29,9 +29,19 @@ pub enum DIDKit {
         #[structopt(flatten)]
         key: KeyArg,
     },
-    /// Output a DID for a given JWK and DID method name or pattern.
+    /// Output a DID for a given JWK according to the provided DID method name or pattern
+    ///
+    /// Deterministically generate a DID from a public key JWK, for a DID method
+    /// that support this functionality.
+    ///
+    /// The DID method to use may be provided in the `method-pattern` argument. The default is
+    /// `did:key`.
+    ///
+    /// For DID methods that have multiple ways of representing a key, `method-pattern` is
+    /// method-specific but typically is a prefix, for example "pkh:tz" to generate a DID that
+    /// begins with `did:pkh:tz`.
     KeyToDID {
-        /// DID method id or pattern. e.g. `key`, `tz`, or `pkh:tz`
+        /// DID method name or pattern. e.g. `key`, `tz`, or `pkh:tz`
         #[structopt(default_value = "key")]
         method_pattern: String,
         #[structopt(flatten)]


### PR DESCRIPTION
As suggested in https://github.com/spruceid/didkit/pull/217#issuecomment-923955313

- Update summary line
- Add paragraphs to help text.
- Use `did:key` by default.

## Resulting output

Using `--help` is a little different from `-h`, with the `structopt` library that we are using here.
It may be possible to output different long-form text for `-h` than `--help`. For now it's the same, written using doc comments. The library generates a more expanded description of the options and flags for `--help`, while it is more compact for `-h`, as you can see in the following output samples.
More info: https://docs.rs/structopt/0.3.25/structopt/index.html#help-messages

<details>
<summary>$ didkit key-to-did -h</summary>

```
didkit-key-to-did 0.1.1
Output a DID for a given JWK according to the provided DID method name or pattern

Deterministically generate a DID from a public key JWK, for a DID method that support this functionality.

The DID method to use may be provided in the `method-pattern` argument. The default is `did:key`.

For DID methods that have multiple ways of representing a key, `method-pattern` is method-specific but typically is a
prefix, for example "pkh:tz" to generate a DID that begins with `did:pkh:tz`.

USAGE:
    didkit key-to-did [OPTIONS] <--key-path <key-path>|--jwk <jwk>|--ssh-agent> [method-pattern]

FLAGS:
    -h, --help         Prints help information
    -S, --ssh-agent    Request signature using SSH Agent
    -V, --version      Prints version information

OPTIONS:
    -j, --jwk <jwk>              WARNING: you should not use this through the CLI in a production environment, prefer
                                 its environment variable. [env: JWK]
    -k, --key-path <key-path>     [env: KEY_PATH=]

ARGS:
    <method-pattern>    DID method name or pattern. e.g. `key`, `tz`, or `pkh:tz` [default: key]
```
</details>

<details>
<summary>$ didkit key-to-did --help</summary>

```
didkit-key-to-did 0.1.1
Output a DID for a given JWK according to the provided DID method name or pattern

Deterministically generate a DID from a public key JWK, for a DID method that support this functionality.

The DID method to use may be provided in the `method-pattern` argument. The default is `did:key`.

For DID methods that have multiple ways of representing a key, `method-pattern` is method-specific but typically is a
prefix, for example "pkh:tz" to generate a DID that begins with `did:pkh:tz`.

USAGE:
    didkit key-to-did [OPTIONS] <--key-path <key-path>|--jwk <jwk>|--ssh-agent> [method-pattern]

FLAGS:
    -h, --help
            Prints help information

    -S, --ssh-agent
            Request signature using SSH Agent

    -V, --version
            Prints version information


OPTIONS:
    -j, --jwk <jwk>
            WARNING: you should not use this through the CLI in a production environment, prefer its environment
            variable. [env: JWK]
    -k, --key-path <key-path>
             [env: KEY_PATH=]


ARGS:
    <method-pattern>
            DID method name or pattern. e.g. `key`, `tz`, or `pkh:tz` [default: key]
```
</details>

The summary line appears in the top-level help text, as in the following.

<details>
<summary>$ didkit -h</summary>

```
didkit-cli 0.1.1

USAGE:
    didkit <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    did-auth                      Authenticate with a DID
    did-dereference               Dereference a DID URL to a resource
    did-resolve                   Resolve a DID to a DID Document
    generate-ed25519-key          Generate and output a Ed25519 keypair in JWK format
    help                          Prints this message or the help of the given subcommand(s)
    key-to-did                    Output a DID for a given JWK according to the provided DID method name or pattern
    key-to-verification-method    Output a verificationMethod DID URL for a JWK and DID method name/pattern
    ssh-pk-to-jwk                 Convert a SSH public key to a JWK
    to-rdf-urdna2015              Convert JSON-LD to URDNA2015-canonicalized RDF N-Quads
    vc-issue-credential           Issue Credential
    vc-issue-presentation         Issue Presentation
    vc-verify-credential          Verify Credential
    vc-verify-presentation        Verify Presentation
```
</details>