### PR TITLE
Test RevocationList2020Status in VC API

### DIFF
--- a/http/tests/vc-api/test.js
+++ b/http/tests/vc-api/test.js
@@ -19,7 +19,7 @@ const DIDKitHTTP = require('./didkit-http');
         options: {
           assertionMethod: "did:key:z6MkgYAGxLBSXa6Ygk1PnUbK2F7zya8juE9nfsZhrvY7c9GD#z6MkgYAGxLBSXa6Ygk1PnUbK2F7zya8juE9nfsZhrvY7c9GD"
         },
-        credentialStatusesSupported: []
+        credentialStatusesSupported: ['RevocationList2020Status']
       }
     ],
     verifyCredentialConfiguration: {


### PR DESCRIPTION
Add `RevocationList2020Status` to `credentialStatusesSupported` in the local VC (HTTP) API Test Suite config, to cause [Revocation List 2020](https://w3c-ccg.github.io/vc-status-rl-2020/) functionality to be tested. This should have been added before, but was forgotten. However, adding it now will probably cause test failure, as the test revocation list credential and its dependent credential statuses have been broken in the renaming of `vc-http-api` to `vc-api`: https://github.com/w3c-ccg/vc-api/issues/236

The test suite itself could also be similarly updated for Spruce's demo instance: https://github.com/w3c-ccg/vc-api-test-suite/blob/a74c63d2d015efcb1c5d22a5d283536026faf5ec/packages/vc-http-api-test-server/config/Spruce.js#L18

Edit: actually, this change would cause issuer tests to run as well, which DIDKit doesn't currently support: the `credentialStatus` issuance option is supposed to result in a `credentialStatus` object added to the resulting verifiable credential:
https://github.com/w3c-ccg/vc-api-test-suite/blob/a74c63d2d015efcb1c5d22a5d283536026faf5ec/packages/vc-http-api-test-server/__tests__/issueCredential.spec.js#L126-L166