### PR TITLE
Remove 'declare' modifier in ambient context

### DIFF
--- a/lib/node/index.d.ts
+++ b/lib/node/index.d.ts
@@ -1,14 +1,14 @@
 declare module "didkit" {
-  declare interface Ed25519Key {
+  interface Ed25519Key {
     kty: string;
     crv: string;
     x: string;
     d: string;
   }
 
-  declare type Key = Ed25519Key | any;
+  type Key = Ed25519Key | any;
 
-  declare interface Options {
+  interface Options {
     proofPurpose?: string;
     verificationMethod?: string;
     challenge?: string;
@@ -16,13 +16,13 @@ declare module "didkit" {
     created?: string;
   }
 
-  declare interface VerifyResult {
+  interface VerifyResult {
     errors: string[];
     warnings: string[];
     checks: string[];
   }
 
-  declare type Method =
+  type Method =
     | "key"
     | "tz"
     | "web"
@@ -46,13 +46,33 @@ declare module "didkit" {
 
   function DIDAuth(did: string, options: Options, key: Key): string;
 
-  function delegateCapability(del: any, options: Options, parents: string[], key: Key): any;
-  function prepareDelegateCapability(del: any, options: Options, parents: string[], key: Key): any;
+  function delegateCapability(
+    del: any,
+    options: Options,
+    parents: string[],
+    key: Key
+  ): any;
+  function prepareDelegateCapability(
+    del: any,
+    options: Options,
+    parents: string[],
+    key: Key
+  ): any;
   function completeDelegateCapability(del: any, prep: any, sig: string): any;
   function verifyDelegation(del: any, options: Options): VerifyResult;
 
-  function invokeCapability(inv: any, target: string, options: Options, key: Key): any;
-  function prepareInvokeCapability(inv: any, target: string, options: Options, key: Key): any;
+  function invokeCapability(
+    inv: any,
+    target: string,
+    options: Options,
+    key: Key
+  ): any;
+  function prepareInvokeCapability(
+    inv: any,
+    target: string,
+    options: Options,
+    key: Key
+  ): any;
   function completeInvokeCapability(inv: any, prep: any, sig: string): any;
   function verifyInvocation(inv: any, del: any, options: Options): VerifyResult;
   function verifyInvocationSignature(inv: any, options: Options): VerifyResult;


### PR DESCRIPTION
File `lib/node/index.d.ts` uses the `declare` modifier inside the already `declare`d didkit module and it causes the following errors

![image](https://user-images.githubusercontent.com/74195338/144997040-6cc7e664-857e-4b0d-8869-d290ea5ec250.png)

Should I provide a repo with a dummy project in order to illustrate the issue more and how to reproduce it ?