### PR TITLE
Remove iOS version from test

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -116,7 +116,7 @@ IOS_LIBS=\
 $(TARGET)/test/ios.stamp: $(TARGET)/universal/release/libdidkit.a $(TARGET)/didkit.h | $(TARGET)/test
 	cd ios && \
 		xcodebuild test \
-			-destination platform="iOS Simulator,name=iPhone 12 Pro,OS=14.4" \
+			-destination platform="iOS Simulator,name=iPhone 12 Pro" \
 			-scheme DIDKitSwift
 	touch $@
 


### PR DESCRIPTION
Address #244

The versions changed recently so the currently indicated version does not work.
Available versions can be seen here:
https://github.com/spruceid/didkit/runs/4668134729?check_suite_focus=true#step:6:985

This change removes the version parameter to make the test work with any version.