### PR TITLE
did:ion and DID operations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SSI_REF: c66972290377c6b4bf9b63b2dfdc047dbdcfd989
+  SSI_REF: cd6a760046c6d95b4f7eda1f79f8fd6d7e7e0f86
 
 defaults:
   run:

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,6 +33,7 @@ thiserror = "1.0"
 bytes = "1.0"
 base64 = "0.12"
 sshkeys = "0.3"
+anyhow = "1.0"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "process"] }

--- a/cli/README.md
+++ b/cli/README.md
@@ -210,11 +210,84 @@ Construct a [DID method transaction][] to create a DID with a given DID method.
 
 A [DID method transaction][] for a DID Create operation.
 
+### `didkit did-update <subcommand>`
+
+Construct a [DID method transaction][] to update a DID.
+
+#### Options
+- `-o <name=value>` - Options for DID Update operation.
+- `-u, --new-update-key <file>` - New JWK file for next DID update operations, as used in Sidetree DID Methods (e.g. `did:ion`).
+- `-U, --update-key <file>` - JWK file for performing this DID update operation
+
+#### Subcommands
+
+Updates to a DID document may be done using these `did-update` subcommands. These correspond roughly to [`didDocumentOperation`][didDocumentOperation] values in DIF DID registration and/or [DID State Patches][did-state-patches] in Sidetree.
+
+- [`set-service`](#didkit-did-update-set-service-id)
+- [`set-verification-method`](#didkit-did-update-set-verification-method-id)
+- [`remove-service`](#didkit-did-update-remove-service-id)
+- [`remove-verification-method`](#didkit-did-update-remove-verification-method-id)
+
+#### Output
+A [DID method transaction][] for a DID Update operation.
+
+### `didkit did-update set-service <id>`
+
+Construct a [DID method transaction][] to add or modify a [service][services] in a DID document.
+
+The identified service object is created if it is exists, or reset if it does not exist, to contain the properties corresponding to the options passed, i.e. the `type` and `serviceEndpoint` properties.
+
+#### Options
+- `-d, --did <did>` - DID whose DID document to update. Default: implied from `<id>`
+- `-t, --type <type>...` - Service type
+- `-e, --endpoint <endpoint>...` - serviceEndpoint URI or JSON object
+
+### `didkit did-update set-verification-method <id>`
+
+Construct a [DID method transaction][] to add or modify a [verification method][verification-methods] in a DID document.
+
+The identified verification method is created if it does not exist, or reset if it already exists. The verification method is constructed to contain properties as passed in the options.
+
+#### Options
+- `-c, --controller <did>` - Verification method controller property
+- `-d, --did <did>` - DID whose DID document to update. Default: implied from `<id>`
+- `-t, --type <type>` - Verification method type (required)
+
+##### Verification relationship options
+At least one [verification relationship][verification-relationships] (proof purpose) must be provided. Each of these options creates the respective verification relationship in the DID document for the verification method object.
+
+- `-S, --assertionMethod` - [Assertion](https://www.w3.org/TR/did-core/#assertion)
+- `-U, --authentication`- [Authentication](https://www.w3.org/TR/did-core/#authentication)
+- `-D, --capabilityDelegation`- [Capability Delegation](https://www.w3.org/TR/did-core/#capability-delegation)
+- `-I, --capabilityInvocation` - [Capability Invocation](https://www.w3.org/TR/did-core/#capability-invocation)
+- `-K, --keyAgreement` - [keyAgreement](https://www.w3.org/TR/did-core/#key-agreement)
+
+##### Public key options
+Exactly one public key property must be provided. Which properties are allowed depends on the verification method type.
+- `-j, --publicKeyJwk <JWK>` - [publicKeyJwk][] value
+- `-k, --publicKeyJwkPath <filename>` - [publicKeyJwk][] value read from file
+- `-m, --publicKeyMultibase <string>` - Multibase-encoded public key ([publicKeyMultibase][] value)
+- `-b, --blockchainAccountId <account>` - [blockchainAccountId](https://w3c-ccg.github.io/security-vocab/#blockchainAccountId) (CAIP-10) value
+
+### `didkit did-update remove-service <id>`
+
+Construct a [DID method transaction][] to remove a [service][services] from a DID document.
+
+#### Options
+- `-d, --did <did>` - DID whose DID document to update. Default: implied from `<id>`
+
+### `didkit did-update remove-verification-method <id>`
+
+Construct a [DID method transaction][] to remove a [verification method][verification-methods] from a DID document.
+
+#### Options
+- `-d, --did <did>` - DID whose DID document to update. Default: implied from `<id>`
+
 ## Concepts
 
 ### DID method transaction
 
-DIDKit's DID method operation commands (e.g. [create](#didkit-did-create-did-method)) do not fully perform the respective operation; instead, they return a data structure representing the partially applied operation, called a **DID method transaction**. The transaction is a verifiable message created by a DID controller to perform a [DID method operation][method-operations]. The transaction can be submitted, published, and/or fully performed, per the DID method.
+DIDKit's DID method operation commands ([create](#didkit-did-create-did-method), [update](#didkit-did-update-subcommand)) do not fully perform the respective operation; instead, they return a data structure representing the partially applied operation, called a **DID method transaction**. The transaction is a verifiable message created by a DID controller to perform a [DID method operation][method-operations]. The transaction can be submitted, published, and/or fully performed, per the DID method.
 
 ## Examples
 
@@ -256,3 +329,11 @@ See the included [shell script](tests/example.sh).
 [did-url-dereferencing-input-metadata]: https://w3c.github.io/did-core/#did-url-dereferencing-input-metadata-properties
 [did-resolution-https-binding]: https://w3c-ccg.github.io/did-resolution/#bindings-https
 [method-operations]: https://www.w3.org/TR/did-core/#method-operations
+[verification-methods]: https://www.w3.org/TR/did-core/#verification-methods
+[verification-relationships]: https://www.w3.org/TR/did-core/#verification-relationships
+[services]: https://www.w3.org/TR/did-core/#services
+[publicKeyJwk]: https://www.w3.org/TR/did-core/#dfn-publickeyjwk
+[publicKeyMultibase]: https://www.w3.org/TR/did-core/#dfn-publickeymultibase
+[DID method transaction]: #did-method-transaction
+[didDocumentOperation]: https://identity.foundation/did-registration/#diddocumentoperation
+[did-state-patches]: https://identity.foundation/sidetree/spec/v1.0.0/#did-state-patches

--- a/cli/README.md
+++ b/cli/README.md
@@ -298,11 +298,22 @@ Construct a [DID method transaction][] to perform a DID recover operation ([DID 
 
 A [DID method transaction][] for a DID Recover operation.
 
+### `didkit did-deactivate <did>`
+
+Construct a [DID method transaction][] to deactivate a DID, if supported by the DID method.
+
+#### Options
+- `-k, --key <key>` - JWK file to perform the DID Deactivate operation
+- `-o <name=value>` - Options for DID deactivate operation.
+
+#### Output
+A [DID method transaction][] for a DID Deactivate operation.
+
 ## Concepts
 
 ### DID method transaction
 
-DIDKit's DID method operation commands ([create](#didkit-did-create-did-method), [update](#didkit-did-update-subcommand), [recover](#didkit-did-recover-did)) do not fully perform the respective operation; instead, they return a data structure representing the partially applied operation, called a **DID method transaction**. The transaction is a verifiable message created by a DID controller to perform a [DID method operation][method-operations]. The transaction can be submitted, published, and/or fully performed, per the DID method.
+DIDKit's DID method operation commands ([create](#didkit-did-create-did-method), [update](#didkit-did-update-subcommand), [recover](#didkit-did-recover-did), [deactivate](#didkit-did-deactivate-did)) do not fully perform the respective operation; instead, they return a data structure representing the partially applied operation, called a **DID method transaction**. The transaction is a verifiable message created by a DID controller to perform a [DID method operation][method-operations]. The transaction can be submitted, published, and/or fully performed, per the DID method.
 
 ## Examples
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -195,6 +195,12 @@ If the `-m` option is used, a JSON array is returned containing the following th
 
 Exit status is zero on success and nonzero on error. On error, if `-m` is used, the error message is returned in the `error` property of the DID dereferencing metadata object on standard output; if `-m` is not used, the error is printed on standard error.
 
+## Concepts
+
+### DID method transaction
+
+DIDKit's DID method operation commands do not fully perform the respective operation; instead, they return a data structure representing the partially applied operation, called a **DID method transaction**. The transaction is a verifiable message created by a DID controller to perform a [DID method operation][method-operations]. The transaction can be submitted, published, and/or fully performed, per the DID method.
+
 ## Examples
 
 See the included [shell script](tests/example.sh).
@@ -234,3 +240,4 @@ See the included [shell script](tests/example.sh).
 [did-url-dereferencing-metadata]: https://w3c.github.io/did-core/#did-url-dereferencing-metadata-properties
 [did-url-dereferencing-input-metadata]: https://w3c.github.io/did-core/#did-url-dereferencing-input-metadata-properties
 [did-resolution-https-binding]: https://w3c-ccg.github.io/did-resolution/#bindings-https
+[method-operations]: https://www.w3.org/TR/did-core/#method-operations

--- a/cli/README.md
+++ b/cli/README.md
@@ -195,11 +195,26 @@ If the `-m` option is used, a JSON array is returned containing the following th
 
 Exit status is zero on success and nonzero on error. On error, if `-m` is used, the error message is returned in the `error` property of the DID dereferencing metadata object on standard output; if `-m` is not used, the error is printed on standard error.
 
+### `didkit did-create <did-method>`
+
+Construct a [DID method transaction][] to create a DID with a given DID method.
+
+#### Options
+
+- `-o <name=value>` - Options for DID Create operation.
+- `-r, --recovery-key <file>` - JWK file for DID recovery and/or deactivation purposes, as used in Sidetree DID methods (e.g. `did:ion`).
+- `-u, --update-key <file>` - JWK file for DID update operations, as used in Sidetree DID Methods (e.g. `did:ion`).
+- `-v, --verification-key <file>` - JWK file for default verification method
+
+#### Output
+
+A [DID method transaction][] for a DID Create operation.
+
 ## Concepts
 
 ### DID method transaction
 
-DIDKit's DID method operation commands do not fully perform the respective operation; instead, they return a data structure representing the partially applied operation, called a **DID method transaction**. The transaction is a verifiable message created by a DID controller to perform a [DID method operation][method-operations]. The transaction can be submitted, published, and/or fully performed, per the DID method.
+DIDKit's DID method operation commands (e.g. [create](#didkit-did-create-did-method)) do not fully perform the respective operation; instead, they return a data structure representing the partially applied operation, called a **DID method transaction**. The transaction is a verifiable message created by a DID controller to perform a [DID method operation][method-operations]. The transaction can be submitted, published, and/or fully performed, per the DID method.
 
 ## Examples
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -283,11 +283,26 @@ Construct a [DID method transaction][] to remove a [verification method][verific
 #### Options
 - `-d, --did <did>` - DID whose DID document to update. Default: implied from `<id>`
 
+### `didkit did-recover <did>`
+
+Construct a [DID method transaction][] to perform a DID recover operation ([DID recovery][did-recovery]), if supported by the DID method.
+
+#### Options
+- `-o <name=value>` - Options for DID Recover operation.
+- `-r, --new-recovery-key <file>` - New JWK file for DID recovery and/or deactivation purposes, as used in Sidetree DID methods (e.g. `did:ion`).
+- `-u, --new-update-key <file>` - New JWK file for next DID update operation, as used in Sidetree DID Methods (e.g. `did:ion`).
+- `-v, --new-verification-key <file>` - New JWK file for default verification method
+- `-R, --recovery-key <file>` - JWK file for performing this DID recover operation
+
+#### Output
+
+A [DID method transaction][] for a DID Recover operation.
+
 ## Concepts
 
 ### DID method transaction
 
-DIDKit's DID method operation commands ([create](#didkit-did-create-did-method), [update](#didkit-did-update-subcommand)) do not fully perform the respective operation; instead, they return a data structure representing the partially applied operation, called a **DID method transaction**. The transaction is a verifiable message created by a DID controller to perform a [DID method operation][method-operations]. The transaction can be submitted, published, and/or fully performed, per the DID method.
+DIDKit's DID method operation commands ([create](#didkit-did-create-did-method), [update](#didkit-did-update-subcommand), [recover](#didkit-did-recover-did)) do not fully perform the respective operation; instead, they return a data structure representing the partially applied operation, called a **DID method transaction**. The transaction is a verifiable message created by a DID controller to perform a [DID method operation][method-operations]. The transaction can be submitted, published, and/or fully performed, per the DID method.
 
 ## Examples
 
@@ -329,6 +344,7 @@ See the included [shell script](tests/example.sh).
 [did-url-dereferencing-input-metadata]: https://w3c.github.io/did-core/#did-url-dereferencing-input-metadata-properties
 [did-resolution-https-binding]: https://w3c-ccg.github.io/did-resolution/#bindings-https
 [method-operations]: https://www.w3.org/TR/did-core/#method-operations
+[did-recovery]: https://www.w3.org/TR/did-core/#did-recovery
 [verification-methods]: https://www.w3.org/TR/did-core/#verification-methods
 [verification-relationships]: https://www.w3.org/TR/did-core/#verification-relationships
 [services]: https://www.w3.org/TR/did-core/#services

--- a/cli/README.md
+++ b/cli/README.md
@@ -309,11 +309,27 @@ Construct a [DID method transaction][] to deactivate a DID, if supported by the 
 #### Output
 A [DID method transaction][] for a DID Deactivate operation.
 
+### `didkit did-from-tx`
+
+Reads a [DID method transaction][] on standard input, and extracts or derives its DID.
+
+#### Output
+
+The DID corresponding to the input transaction.
+
+### `didkit did-submit-tx <did>`
+
+Reads a [DID method transaction][] on standard input, and submits it in a method-specific way. Returns exit status zero if the transaction was successfully submitted.
+
+#### Output
+
+A method-specific data structure.
+
 ## Concepts
 
 ### DID method transaction
 
-DIDKit's DID method operation commands ([create](#didkit-did-create-did-method), [update](#didkit-did-update-subcommand), [recover](#didkit-did-recover-did), [deactivate](#didkit-did-deactivate-did)) do not fully perform the respective operation; instead, they return a data structure representing the partially applied operation, called a **DID method transaction**. The transaction is a verifiable message created by a DID controller to perform a [DID method operation][method-operations]. The transaction can be submitted, published, and/or fully performed, per the DID method.
+DIDKit's DID method operation commands ([create](#didkit-did-create-did-method), [update](#didkit-did-update-subcommand), [recover](#didkit-did-recover-did), [deactivate](#didkit-did-deactivate-did)) do not fully perform the respective operation; instead, they return a data structure representing the partially applied operation, called a **DID method transaction**. The transaction is a verifiable message created by a DID controller to perform a [DID method operation][method-operations]. The transaction can be submitted, published, and/or fully performed, per the DID method, using the [did-submit-tx](#didkit-did-submit-tx-did) subcommand.
 
 ## Examples
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -335,6 +335,13 @@ DIDKit's DID method operation commands ([create](#didkit-did-create-did-method),
 
 See the included [shell script](tests/example.sh).
 
+See also the following shell scripts demonstrating create, update, recover and deactivate operations:
+- [create and update service](tests/ion-create-update-svc.sh)
+- [create and update verification method](tests/ion-create-update-vm.sh)
+- [create and recover](tests/ion-create-recover.sh)
+- [create and deactivate](tests/ion-create-deactivate.sh)
+
+[ssi]: https://github.com/spruceid/ssi
 [JWK]: https://tools.ietf.org/html/rfc7517
 [ld-proofs]: https://w3c-ccg.github.io/ld-proofs/
 [vc-http-api]: https://w3c-ccg.github.io/vc-http-api/

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,6 +3,7 @@ use std::io::{stdin, stdout, BufReader, BufWriter, Read, Write};
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use anyhow::Result as AResult;
 use chrono::prelude::*;
 use clap::{AppSettings, ArgGroup, Parser, StructOpt};
 use serde::Serialize;
@@ -374,7 +375,7 @@ set. For more info, see the manual for ssh-agent(1) and ssh-add(1).
     }
 }
 
-fn main() {
+fn main() -> AResult<()> {
     let rt = runtime::get().unwrap();
     let opt = DIDKit::parse();
     let ssh_agent_sock;
@@ -772,4 +773,5 @@ fn main() {
             }
         }
     }
+    Ok(())
 }

--- a/cli/tests/ion-create-deactivate.sh
+++ b/cli/tests/ion-create-deactivate.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+set -e
+cd "$(dirname "$0")"
+
+# Create and use temp directory if does not already exist
+dir=did-ion-test
+if test -d "$dir"
+then
+	printf 'Directory already exists: %s\n' "$dir" >&2
+	exit 1
+fi
+mkdir "$dir"
+cd "$dir"
+
+# Generate initial update keypair and initial recovery keypair
+didkit key generate secp256k1 > 1-u.jwk
+didkit key generate secp256k1 > 1-r.jwk
+# Construct Create operation with initial public keys
+didkit did-create ion -r 1-r.jwk -u 1-u.jwk | tee 1-create.json
+# Get long-form and short-form DID from Create operation
+longdid=$(didkit did-from-tx < 1-create.json)
+shortdid=$(echo -n "$longdid" | sed 's/:[^:]*$//')
+didsuffix=$(echo -n "$shortdid" | sed 's/.*://')
+echo "Sidetree DID Suffix: $didsuffix"
+echo "DID (long-form/unpublished): $longdid"
+echo "DID (short-form/canonical): $shortdid"
+
+# Now that the DID suffix is set, rename the directory to it.
+cd ..
+mv "$dir" "$didsuffix"
+cd "$didsuffix"
+
+# Submit Create operation
+export DID_ION_API_URL=http://localhost:3000/
+read -p "Press enter to submit Create operation. " _
+didkit did-submit-tx < 1-create.json
+
+# Construct Deactivate operation
+didkit did-deactivate "$shortdid" -k 1-r.jwk | tee 2-deactivate.json
+# Submit operation
+read -p 'Press enter to submit Deactivate operation. ' _
+if ! didkit did-submit-tx < 2-deactivate.json
+then
+	# Provide retry in case submission failed, e.g. because the
+	# create operation has not yet been processed.
+	read -p 'Press enter to retry Deactivate operation. ' _
+	didkit did-submit-tx < 2-deactivate.json
+fi

--- a/cli/tests/ion-create-recover.sh
+++ b/cli/tests/ion-create-recover.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -e
+cd "$(dirname "$0")"
+
+# Create and use temp directory if does not already exist
+dir=did-ion-test
+if test -d "$dir"
+then
+	printf 'Directory already exists: %s\n' "$dir" >&2
+	exit 1
+fi
+mkdir "$dir"
+cd "$dir"
+
+# Generate initial update keypair and initial recovery keypair
+didkit key generate secp256k1 > 1-u.jwk
+didkit key generate secp256k1 > 1-r.jwk
+# Construct Create operation with initial public keys
+didkit did-create ion -r 1-r.jwk -u 1-u.jwk | tee 1-create.json
+# Get long-form and short-form DID from Create operation
+longdid=$(didkit did-from-tx < 1-create.json)
+shortdid=$(echo -n "$longdid" | sed 's/:[^:]*$//')
+didsuffix=$(echo -n "$shortdid" | sed 's/.*://')
+echo "Sidetree DID Suffix: $didsuffix"
+echo "DID (long-form/unpublished): $longdid"
+echo "DID (short-form/canonical): $shortdid"
+
+# Now that the DID suffix is set, rename the directory to it.
+cd ..
+mv "$dir" "$didsuffix"
+cd "$didsuffix"
+
+# Submit Create operation
+export DID_ION_API_URL=http://localhost:3000/
+read -p "Press enter to submit Create operation. " _
+didkit did-submit-tx < 1-create.json
+
+# Generate new update keypair and recovery keypair for recover operation
+didkit key generate secp256k1 > 2-u.jwk
+didkit key generate secp256k1 > 2-r.jwk
+
+# Construct Recover operation
+didkit did-recover "$shortdid" -R 1-r.jwk -r 2-r.jwk -u 2-u.jwk | tee 2-recover.json
+# Submit operation
+read -p 'Press enter to submit Recover operation. ' _
+if ! didkit did-submit-tx < 2-recover.json
+then
+	# Provide retry in case submission failed, e.g. because the
+	# create operation has not yet been processed.
+	read -p 'Press enter to retry Recover operation. ' _
+	didkit did-submit-tx < 2-recover.json
+fi

--- a/cli/tests/ion-create-update-svc.sh
+++ b/cli/tests/ion-create-update-svc.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+set -e
+cd "$(dirname "$0")"
+export DID_ION_API_URL=http://localhost:3000/
+
+# Create and use temp directory if does not already exist
+dir=did-ion-test
+if test -d "$dir"
+then
+	printf 'Directory already exists: %s\n' "$dir" >&2
+	exit 1
+fi
+mkdir "$dir"
+cd "$dir"
+
+# Generate initial update keypair and initial recovery keypair
+didkit key generate secp256k1 > 1-u.jwk
+didkit key generate secp256k1 > 1-r.jwk
+# Construct Create operation with initial public keys
+didkit did-create ion -r 1-r.jwk -u 1-u.jwk | tee 1-create.json
+# Get long-form and short-form DID from Create operation
+longdid=$(didkit did-from-tx < 1-create.json)
+shortdid=$(echo -n "$longdid" | sed 's/:[^:]*$//')
+didsuffix=$(echo -n "$shortdid" | sed 's/.*://')
+echo "Sidetree DID Suffix: $didsuffix"
+echo "DID (long-form/unpublished): $longdid"
+echo "DID (short-form/canonical): $shortdid"
+
+# Now that the DID suffix is set, rename the directory to it.
+cd ..
+mv "$dir" "$didsuffix"
+cd "$didsuffix"
+
+
+# Submit Create operation
+read -p "Press enter to submit Create operation. " _
+didkit did-submit-tx < 1-create.json
+
+# Construct DID URL for new service endpoint
+svc="$shortdid#svc-1"
+
+# Construct Update operation to add verification key to DID document
+didkit did-update -U 1-u.jwk -u 2-u.jwk \
+	set-service "$svc" \
+	-t DIDKitDemoService \
+	-e https://demo.didkit.dev/ \
+	| tee 2-update.json
+# Submit Update operation
+read -p 'Press enter to submit Update operation. ' _
+if ! didkit did-submit-tx < 2-update.json
+then
+	read -p 'Press enter to retry submit operation. ' _
+	didkit did-submit-tx < 2-update.json
+fi
+

--- a/cli/tests/ion-create-update-vm.sh
+++ b/cli/tests/ion-create-update-vm.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -e
+cd "$(dirname "$0")"
+
+# Create and use temp directory if does not already exist
+dir=did-ion-test
+if test -d "$dir"
+then
+	printf 'Directory already exists: %s\n' "$dir" >&2
+	exit 1
+fi
+mkdir "$dir"
+cd "$dir"
+
+# Generate initial update keypair and initial recovery keypair
+didkit key generate secp256k1 > 1-u.jwk
+didkit key generate secp256k1 > 1-r.jwk
+# Construct Create operation with initial public keys
+didkit did-create ion -r 1-r.jwk -u 1-u.jwk | tee 1-create.json
+# Get long-form and short-form DID from Create operation
+longdid=$(didkit did-from-tx < 1-create.json)
+shortdid=$(echo -n "$longdid" | sed 's/:[^:]*$//')
+didsuffix=$(echo -n "$shortdid" | sed 's/.*://')
+echo "Sidetree DID Suffix: $didsuffix"
+echo "DID (long-form/unpublished): $longdid"
+echo "DID (short-form/canonical): $shortdid"
+
+# Now that the DID suffix is set, rename the directory to it.
+cd ..
+mv "$dir" "$didsuffix"
+cd "$didsuffix"
+
+# Submit Create operation
+export DID_ION_API_URL=http://localhost:3000/
+read -p "Press enter to submit Create operation. " _
+didkit did-submit-tx < 1-create.json
+
+# Generate verification key to be added to DID document
+didkit key generate secp256k1 > 2-v.jwk
+# Construct DID URL for new verification method
+vm="$shortdid#key-1"
+
+# Generate new update key keypair
+didkit key generate secp256k1 > 2-u.jwk
+# Construct Update operation to add verification key to DID document
+didkit did-update -U 1-u.jwk -u 2-u.jwk \
+	set-verification-method "$vm" -k 2-v.jwk \
+	--authentication --assertionMethod -t JsonWebKey2020 \
+	| tee 2-update.json
+# Submit Update operation
+read -p 'Press enter to submit Update operation. ' _
+if ! didkit did-submit-tx < 2-update.json
+then
+	read -p 'Press enter to retry submit operation. ' _
+	didkit did-submit-tx < 2-update.json
+fi
+

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -37,6 +37,7 @@ did-pkh = { version = "0.1", path = "../../ssi/did-pkh" }
 did-web = { version = "^0.1.1", path = "../../ssi/did-web" }
 did-webkey = { version = "0.1", path = "../../ssi/did-webkey", default-features = false }
 did-onion = { version = "^0.1.1", path = "../../ssi/did-onion" }
+did-ion = { version = "^0.1.0", path = "../../ssi/did-ion" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 # TODO feature-gate JNI, or extract it in another crate like we do for Python (and probably WASM as well)

--- a/lib/src/did_methods.rs
+++ b/lib/src/did_methods.rs
@@ -3,14 +3,26 @@ use did_method_key::DIDKey;
 use did_onion::DIDOnion;
 use did_pkh::DIDPKH;
 // use did_sol::DIDSol;
+use did_ion::DIDION;
 use did_tz::DIDTz;
 use did_web::DIDWeb;
 use did_webkey::DIDWebKey;
-use ssi::did::DIDMethods;
+use ssi::did::{DIDMethod, DIDMethods};
+use std::env::VarError;
 
 lazy_static! {
     static ref DIDTZ: DIDTz = DIDTz::default();
     static ref DIDONION: DIDOnion = DIDOnion::default();
+    static ref ION: DIDION = DIDION::new(
+        match std::env::var("DID_ION_API_URL") {
+            Ok(string) => Some(string),
+            Err(VarError::NotPresent) => None,
+            Err(VarError::NotUnicode(err)) => {
+                eprintln!("Unable to parse DID_ION_API_URL: {:?}", err);
+                None
+            }
+        }
+    );
     pub static ref DID_METHODS: DIDMethods<'static> = {
         let mut methods = DIDMethods::default();
         methods.insert(&DIDKey);
@@ -21,6 +33,7 @@ lazy_static! {
         methods.insert(&DIDWebKey);
         methods.insert(&DIDPKH);
         methods.insert(&*DIDONION);
+        methods.insert(&*ION);
         methods
     };
 }

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -7,6 +7,7 @@ use std::ptr;
 
 use serde_json::Error as JSONError;
 use ssi::error::Error as SSIError;
+use std::error::Error as StdError;
 use std::io::Error as IOError;
 use std::str::Utf8Error;
 
@@ -53,6 +54,8 @@ impl Error {
         }
     }
 }
+
+impl StdError for Error {}
 
 #[no_mangle]
 /// Retrieve a human-readable description of the most recent error encountered by a DIDKit C

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -14,7 +14,7 @@ extern crate lazy_static;
 
 pub use crate::did_methods::DID_METHODS;
 pub use crate::error::Error;
-pub use ssi::did::{DIDMethod, Document, Source};
+pub use ssi::did::{DIDCreate, DIDMethod, Document, Source};
 #[cfg(feature = "http-did")]
 pub use ssi::did_resolve::HTTPDIDResolver;
 pub use ssi::did_resolve::{

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -15,7 +15,7 @@ extern crate lazy_static;
 pub use crate::did_methods::DID_METHODS;
 pub use crate::error::Error;
 pub use ssi::did::{
-    DIDCreate, DIDDocumentOperation, DIDMethod, DIDUpdate, Document, Source, DIDURL,
+    DIDCreate, DIDDocumentOperation, DIDMethod, DIDRecover, DIDUpdate, Document, Source, DIDURL,
 };
 #[cfg(feature = "http-did")]
 pub use ssi::did_resolve::HTTPDIDResolver;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -14,7 +14,9 @@ extern crate lazy_static;
 
 pub use crate::did_methods::DID_METHODS;
 pub use crate::error::Error;
-pub use ssi::did::{DIDCreate, DIDMethod, Document, Source};
+pub use ssi::did::{
+    DIDCreate, DIDDocumentOperation, DIDMethod, DIDUpdate, Document, Source, DIDURL,
+};
 #[cfg(feature = "http-did")]
 pub use ssi::did_resolve::HTTPDIDResolver;
 pub use ssi::did_resolve::{

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -15,7 +15,8 @@ extern crate lazy_static;
 pub use crate::did_methods::DID_METHODS;
 pub use crate::error::Error;
 pub use ssi::did::{
-    DIDCreate, DIDDocumentOperation, DIDMethod, DIDRecover, DIDUpdate, Document, Source, DIDURL,
+    DIDCreate, DIDDeactivate, DIDDocumentOperation, DIDMethod, DIDRecover, DIDUpdate, Document,
+    Source, DIDURL,
 };
 #[cfg(feature = "http-did")]
 pub use ssi::did_resolve::HTTPDIDResolver;


### PR DESCRIPTION
Integrate Sidetree/ION implementation and DID operations from https://github.com/spruceid/ssi/pull/379.

- [x] Add did:ion method/resolver
- [x] Add generate-secp256k1-key command
- [x] Add create command
- [x] Submit operations to Sidetree/ION API
- [x] Add update command
- [x] Add recover command
- [x] Add deactivate command
- [x] Update readme to document new commands

## Example Usage
```
# Generate initial keys
$ didkit generate-secp256k1-key > update0.jwk
$ didkit generate-secp256k1-key > recovery0.jwk
$ didkit generate-secp256k1-key > signing0.jwk

# Create DID
$ did=$(didkit did-create ion -r recovery0.jwk -u update0.jwk -s signing0.jwk)

# Resolve long-form DID
$ DID_ION_API_URL=http://localhost:3000/ didkit did-resolve "$did"
```