### PR TITLE
Enable manual dispatch of actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -6,6 +6,7 @@ on:
       - main
   release:
       types: [published, created, edited]
+  workflow_dispatch:
 
 jobs:
   build-and-push:

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -3,6 +3,7 @@ name: smoke_tests
 on:
   schedule:
     - cron:  '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Some test failures happen because of environmental/external reasons, so it may be useful to trigger the CI to re-run rather than push another commit.

Also, since the Docker images are published from didkit's main branch and ssi's main branch, it may be useful to be able to trigger a DIDKit Docker image deploy when there are changes in ssi but not in didkit.