### PR TITLE
Enable using did:webkey:gpg in didkit-wasm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SSI_REF: c66972290377c6b4bf9b63b2dfdc047dbdcfd989
+  SSI_REF: fix/pgp-rust-wasm
 
 defaults:
   run:

--- a/lib/web/Cargo.toml
+++ b/lib/web/Cargo.toml
@@ -33,6 +33,11 @@ path = "../../../ssi/did-tezos"
 default-features = false
 features = ["secp256k1", "dalek", "p256"]
 
+[dependencies.did-webkey]
+path = "../../../ssi/did-webkey"
+default-features = false
+features = ["crypto-rust"]
+
 [dev-dependencies]
 wasm-bindgen-test = "0.2"
 


### PR DESCRIPTION
With https://github.com/spruceid/ssi/pull/373 / https://github.com/spruceid/ssi/pull/390, the did-webkey crate must be required with a default feature disabled.