### PR TITLE
Disable did-webkey default features

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -35,7 +35,7 @@ did-ethr = { version = "0.1", path = "../../ssi/did-ethr" }
 did-pkh = { version = "0.1", path = "../../ssi/did-pkh" }
 #did-sol = { version = "0.0.1", path = "../../ssi/did-sol" }
 did-web = { version = "^0.1.1", path = "../../ssi/did-web" }
-did-webkey = { version = "0.1", path = "../../ssi/did-webkey" }
+did-webkey = { version = "0.1", path = "../../ssi/did-webkey", default-features = false }
 did-onion = { version = "^0.1.1", path = "../../ssi/did-onion" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/lib/web/Cargo.toml
+++ b/lib/web/Cargo.toml
@@ -33,6 +33,10 @@ path = "../../../ssi/did-tezos"
 default-features = false
 features = ["secp256k1", "dalek", "p256"]
 
+[dependencies.did-webkey]
+path = "../../../ssi/did-webkey"
+default-features = false
+
 [dev-dependencies]
 wasm-bindgen-test = "0.2"
 


### PR DESCRIPTION
This is needed for https://github.com/spruceid/ssi/pull/373 / https://github.com/spruceid/ssi/pull/390: the `webkey:gpg` implementation adds default features which must be omitted for wasm.