### PR TITLE
didkit v0.4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,13 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-cargo-
 
+    - name: Install Rust old stable with incremental compilation
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.58.0
+        profile: minimal
+        default: true
+
     - name: Build
       run: cargo build --verbose
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SSI_REF: cd6a760046c6d95b4f7eda1f79f8fd6d7e7e0f86
+  SSI_REF: 82786506b9aaafb08e1fec68d57b4b58eaa14479
 
 defaults:
   run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.4.0] - 2022-03-03
 ### Added
 - DID Resolution function added to didkit-node ([#237](https://github.com/spruceid/didkit/pull/237)).
 - Add key generation subcommands: `didkit key generate ...` ([#259](https://github.com/spruceid/didkit/pull/259)).
@@ -144,7 +146,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [wasm-pack]: https://rustwasm.github.io/wasm-pack/
 [zcap-ld]: https://w3c-ccg.github.io/zcap-ld/
 
-[Unreleased]: https://github.com/spruceid/didkit/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/spruceid/didkit/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/spruceid/didkit/releases/tag/v0.4.0
 [0.3.0]: https://github.com/spruceid/didkit/releases/tag/v0.3.0
 [0.2.1]: https://github.com/spruceid/didkit/releases/tag/v0.2.1
 [0.2.0]: https://github.com/spruceid/didkit/releases/tag/v0.2.0

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "3.0", features = ["derive", "env"] }
 did-method-key = { version = "0.1", path = "../../ssi/did-key" }
-ssi = { version = "0.3", path = "../../ssi", default-features = false }
+ssi = { version = "0.4", path = "../../ssi", default-features = false }
 thiserror = "1.0"
 bytes = "1.0"
 base64 = "0.12"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,7 +23,7 @@ ring = ["ssi/ring"]
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-didkit = { version = "0.3", path = "../lib", features = ["http-did"] }
+didkit = { version = "0.4", path = "../lib", features = ["http-did"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "3.0", features = ["derive", "env"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didkit-cli"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 description = "Command-line interface for Verifiable Credentials and Decentralized Identifiers."

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didkit-http"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 description = "HTTP server for Verifiable Credentials and Decentralized Identifiers."

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -31,7 +31,7 @@ serde_urlencoded = "0.7"
 hyper = { version = "0.14", features = ["server", "client", "http1", "http2", "stream"] }
 tower-service = "0.3"
 futures-util = { version = "0.3", default-features = false }
-ssi = { version = "0.3", path = "../../ssi", default-features = false }
+ssi = { version = "0.4", path = "../../ssi", default-features = false }
 percent-encoding = "2.1"
 
 [dev-dependencies]

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -22,7 +22,7 @@ ring = ["ssi/ring"]
 
 [dependencies]
 didkit = { version = "0.4", path = "../lib", features = ["http-did"] }
-didkit-cli = { version = "^0.1.1", path = "../cli" }
+didkit-cli = { version = "0.2", path = "../cli" }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 clap = { version = "3.0", features = ["derive", "env"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -21,7 +21,7 @@ default = ["ring"]
 ring = ["ssi/ring"]
 
 [dependencies]
-didkit = { version = "0.3", path = "../lib", features = ["http-did"] }
+didkit = { version = "0.4", path = "../lib", features = ["http-did"] }
 didkit-cli = { version = "^0.1.1", path = "../cli" }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 clap = { version = "3.0", features = ["derive", "env"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -29,15 +29,15 @@ p256 = ["ssi/secp256r1", "did-tz/p256", "did-webkey/p256", "did-method-key/secp2
 
 [dependencies]
 ssi = { version = "0.4", path = "../../ssi", default-features = false }
-did-method-key = { version = "^0.1.2", path = "../../ssi/did-key" }
+did-method-key = { version = "^0.1.2", path = "../../ssi/did-key", default-features = false }
 did-tz = { version = "^0.1.1", path = "../../ssi/did-tezos", default-features = false }
-did-ethr = { version = "0.1", path = "../../ssi/did-ethr" }
-did-pkh = { version = "0.1", path = "../../ssi/did-pkh" }
+did-ethr = { version = "0.1", path = "../../ssi/did-ethr", default-features = false }
+did-pkh = { version = "0.1", path = "../../ssi/did-pkh", default-features = false }
 #did-sol = { version = "0.0.1", path = "../../ssi/did-sol" }
-did-web = { version = "^0.1.1", path = "../../ssi/did-web" }
+did-web = { version = "^0.1.1", path = "../../ssi/did-web", default-features = false }
 did-webkey = { version = "0.1", path = "../../ssi/did-webkey", default-features = false }
-did-onion = { version = "^0.1.1", path = "../../ssi/did-onion" }
-did-ion = { version = "^0.1.0", path = "../../ssi/did-ion" }
+did-onion = { version = "^0.1.1", path = "../../ssi/did-onion", default-features = false }
+did-ion = { version = "^0.1.0", path = "../../ssi/did-ion", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 # TODO feature-gate JNI, or extract it in another crate like we do for Python (and probably WASM as well)

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didkit"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 description = "Library for Verifiable Credentials and Decentralized Identifiers."

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -28,7 +28,7 @@ secp256k1 = ["ssi/libsecp256k1", "did-tz/secp256k1", "did-method-key/secp256k1"]
 p256 = ["ssi/secp256r1", "did-tz/p256", "did-webkey/p256", "did-method-key/secp256r1"]
 
 [dependencies]
-ssi = { version = "0.3", path = "../../ssi", default-features = false }
+ssi = { version = "0.4", path = "../../ssi", default-features = false }
 did-method-key = { version = "^0.1.2", path = "../../ssi/did-key" }
 did-tz = { version = "^0.1.1", path = "../../ssi/did-tezos", default-features = false }
 did-ethr = { version = "0.1", path = "../../ssi/did-ethr" }

--- a/lib/node/Cargo.toml
+++ b/lib/node/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.4"
 path = "../../../ssi"
 
 [dependencies.didkit]
-version = "0.3"
+version = "0.4"
 default-features = false
 path = "../"
 

--- a/lib/node/Cargo.toml
+++ b/lib/node/Cargo.toml
@@ -16,7 +16,7 @@ serde = "1.0"
 serde_json = "1.0"
 
 [dependencies.ssi]
-version = "0.3"
+version = "0.4"
 path = "../../../ssi"
 
 [dependencies.didkit]

--- a/lib/web/Cargo.toml
+++ b/lib/web/Cargo.toml
@@ -26,6 +26,7 @@ features = ["ed25519-dalek", "sha2", "rsa", "rand", "libsecp256k1", "p256"]
 
 [dependencies.did-method-key]
 path = "../../../ssi/did-key"
+default-features = false
 features = ["secp256k1", "p256"]
 
 [dependencies.did-tz]


### PR DESCRIPTION
Updated to use ssi v0.4 (https://github.com/spruceid/ssi/pull/401).

Changelog updated for changes since v0.3.0.

Updates for new ssi DID method crate versions (https://github.com/spruceid/ssi/pull/403) should not be needed, since the crate versions will still be matched (They are all v0.1.x). `default-features=no` is set for the DID method crates, because of https://github.com/spruceid/ssi/pull/402.

Updated crate versions for publishing:
- didkit v0.4.0
- didkit-cli v0.2.0
- didkit-http v0.2.0