### PR TITLE
Allow setting did:onion proxy URL

### DIFF
--- a/lib/src/did_methods.rs
+++ b/lib/src/did_methods.rs
@@ -12,7 +12,20 @@ use std::env::VarError;
 
 lazy_static! {
     static ref DIDTZ: DIDTz = DIDTz::default();
-    static ref DIDONION: DIDOnion = DIDOnion::default();
+    static ref DIDONION: DIDOnion = {
+        let mut onion = DIDOnion::default();
+        if let Some(url) = match std::env::var("DID_ONION_PROXY_URL") {
+            Ok(url) => Some(url),
+            Err(VarError::NotPresent) => None,
+            Err(VarError::NotUnicode(err)) => {
+                eprintln!("Unable to parse DID_ONION_PROXY_URL: {:?}", err);
+                None
+            }
+        } {
+            onion.proxy_url = url;
+        }
+        onion
+    };
     static ref ION: DIDION = DIDION::new(
         match std::env::var("DID_ION_API_URL") {
             Ok(string) => Some(string),


### PR DESCRIPTION
Re: https://github.com/spruceid/didkit/issues/138#issuecomment-1097129778

Allow setting any [request proxy URL](https://docs.rs/reqwest/latest/reqwest/struct.Proxy.html) for `did:onion`, via environmental variable 
`DID_ONION_PROXY_URL`. The default value is effectively `socks5h://127.0.0.1:9050/`