### PR TITLE
update ssi imports and types to post-restructure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SSI_REF: d19575d2d4251ddc200d54845a59174971964147
+  SSI_REF: main
 
 defaults:
   run:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SSI_REF: e865520085dc1b88f0a26fa94380b7590cbf6725
+  SSI_REF: d19575d2d4251ddc200d54845a59174971964147
 
 defaults:
   run:

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,12 +16,12 @@ use didkit::generate_proof;
 use didkit::{
     dereference, get_verification_method, runtime, DIDCreate, DIDDeactivate, DIDDocumentOperation,
     DIDMethod, DIDRecover, DIDResolver, DIDUpdate, DereferencingInputMetadata, Error,
-    LinkedDataProofOptions, Metadata, ProofFormat, ProofPurpose, ResolutionInputMetadata,
-    ResolutionResult, Source, VerifiableCredential, VerifiablePresentation, DIDURL, DID_METHODS,
-    JWK, URI,
+    LinkedDataProofOptions, Metadata, ProofFormat, ResolutionInputMetadata, ResolutionResult,
+    Source, VerifiableCredential, VerifiablePresentation, VerificationRelationship, DIDURL,
+    DID_METHODS, JWK, URI,
 };
 use didkit_cli::opts::ResolverOptions;
-use ssi::did::{DIDMethodTransaction, Service, ServiceEndpoint, VerificationRelationship};
+use ssi::did::{DIDMethodTransaction, Service, ServiceEndpoint};
 use ssi::one_or_many::OneOrMany;
 
 #[derive(StructOpt, Debug)]
@@ -415,7 +415,7 @@ pub struct ProofOptions {
     #[clap(env, short, long)]
     pub verification_method: Option<URI>,
     #[clap(env, short, long)]
-    pub proof_purpose: Option<ProofPurpose>,
+    pub proof_purpose: Option<VerificationRelationship>,
     #[clap(env, short, long)]
     pub created: Option<DateTime<Utc>>,
     #[clap(env, short = 'C', long)]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -19,13 +19,24 @@ include = [
 ]
 
 [features]
-default = ["ring", "secp256k1", "p256"]
-ring = ["ssi/ring"]
-no-ring = ["ssi/ed25519-dalek", "ssi/sha2", "ssi/rsa", "ssi/rand"]
-wasm = []
+default = ["w3c", "eip"]
+
+w3c = ["ssi/w3c", "secp256k1", "secp256r1", "ed25519", "rsa"]
+secp256k1 = ["ssi/secp256k1", "did-tz/secp256k1", "did-method-key/secp256k1", "did-ion/secp256k1"]
+secp256r1 = ["ssi/secp256r1", "did-tz/secp256r1", "did-webkey/secp256r1", "did-method-key/secp256r1", "did-ion/secp256r1"]
+ed25519 = ["ssi/ed25519", "did-tz/ed25519", "did-ion/ed25519"]
+rsa = ["ssi/rsa", "did-ion/rsa"]
+
+aleo = ["ssi/aleo"]
+eip = ["ssi/eip"]
+tezos = ["ssi/tezos"]
+solana = ["ssi/solana"]
+
 http-did = ["ssi/http-did"]
-secp256k1 = ["ssi/libsecp256k1", "did-tz/secp256k1", "did-method-key/secp256k1"]
-p256 = ["ssi/secp256r1", "did-tz/p256", "did-webkey/p256", "did-method-key/secp256r1"]
+
+wasm = []
+ring = ["ssi/ring"]
+openssl = ["ssi/openssl"]
 
 [dependencies]
 ssi = { version = "0.4", path = "../../ssi", default-features = false }

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -1,15 +1,7 @@
-use std::cell::BorrowError;
 use std::ffi::CString;
-use std::ffi::NulError;
 use std::fmt;
 use std::os::raw::{c_char, c_int};
 use std::ptr;
-
-use serde_json::Error as JSONError;
-use ssi::error::Error as SSIError;
-use std::error::Error as StdError;
-use std::io::Error as IOError;
-use std::str::Utf8Error;
 
 static UNKNOWN_ERROR: &str = "Unable to create error string\0";
 
@@ -18,19 +10,31 @@ thread_local! {
     pub static LAST_ERROR: RefCell<Option<(i32, CString)>> = RefCell::new(None);
 }
 
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
-    SSI(ssi::error::Error),
-    Null(NulError),
-    Utf8(Utf8Error),
-    Borrow(BorrowError),
-    IO(IOError),
+    #[error(transparent)]
+    VC(#[from] ssi::vc::Error),
+    #[error(transparent)]
+    JWK(#[from] ssi::jwk::Error),
+    #[error(transparent)]
+    Null(#[from] std::ffi::NulError),
+    #[error(transparent)]
+    Utf8(#[from] std::str::Utf8Error),
+    #[error(transparent)]
+    Borrow(#[from] std::cell::BorrowError),
+    #[error(transparent)]
+    IO(#[from] std::io::Error),
+    #[error("Unable to generate DID")]
     UnableToGenerateDID,
+    #[error("Unknown DID method")]
     UnknownDIDMethod,
+    #[error("Unable to get verification method")]
     UnableToGetVerificationMethod,
+    #[error("Unknown proof format: {0}")]
     UnknownProofFormat(String),
 
     #[doc(hidden)]
+    #[error("")]
     __Nonexhaustive,
 }
 
@@ -47,15 +51,14 @@ impl Error {
     fn get_code(&self) -> c_int {
         // TODO: try to give each individual error its own number
         match self {
-            Error::SSI(_) => 1,
+            Error::VC(_) => 1,
             Error::Null(_) => 2,
             Error::Utf8(_) => 3,
+            Error::JWK(_) => 4,
             _ => -1,
         }
     }
 }
-
-impl StdError for Error {}
 
 #[no_mangle]
 /// Retrieve a human-readable description of the most recent error encountered by a DIDKit C
@@ -84,54 +87,15 @@ pub extern "C" fn didkit_error_code() -> c_int {
     })
 }
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::SSI(e) => e.fmt(f),
-            Error::Null(e) => e.fmt(f),
-            Error::Utf8(e) => e.fmt(f),
-            Error::UnableToGenerateDID => write!(f, "Unable to generate DID"),
-            Error::UnknownDIDMethod => write!(f, "Unknown DID method"),
-            Error::UnableToGetVerificationMethod => write!(f, "Unable to get verification method"),
-            Error::UnknownProofFormat(format) => write!(f, "Unknown proof format: {}", format),
-            _ => unreachable!(),
-        }
+impl From<serde_json::Error> for Error {
+    fn from(err: serde_json::Error) -> Error {
+        Error::VC(ssi::vc::Error::from(err))
     }
 }
 
-impl From<SSIError> for Error {
-    fn from(err: SSIError) -> Error {
-        Error::SSI(err)
-    }
-}
-
-impl From<JSONError> for Error {
-    fn from(err: JSONError) -> Error {
-        Error::SSI(SSIError::from(err))
-    }
-}
-
-impl From<NulError> for Error {
-    fn from(err: NulError) -> Error {
-        Error::Null(err)
-    }
-}
-
-impl From<Utf8Error> for Error {
-    fn from(err: Utf8Error) -> Error {
-        Error::Utf8(err)
-    }
-}
-
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Error {
-        Error::IO(err)
-    }
-}
-
-impl From<BorrowError> for Error {
-    fn from(err: BorrowError) -> Error {
-        Error::Borrow(err)
+impl From<ssi::ldp::Error> for Error {
+    fn from(e: ssi::ldp::Error) -> Error {
+        ssi::vc::Error::from(e).into()
     }
 }
 

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -15,6 +15,8 @@ pub enum Error {
     #[error(transparent)]
     VC(#[from] ssi::vc::Error),
     #[error(transparent)]
+    Zcap(#[from] ssi::zcap::Error),
+    #[error(transparent)]
     JWK(#[from] ssi::jwk::Error),
     #[error(transparent)]
     Null(#[from] std::ffi::NulError),
@@ -55,6 +57,7 @@ impl Error {
             Error::Null(_) => 2,
             Error::Utf8(_) => 3,
             Error::JWK(_) => 4,
+            Error::Zcap(_) => 5,
             _ => -1,
         }
     }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -27,7 +27,7 @@ pub use ssi::did_resolve::{
 };
 pub use ssi::jsonld::ContextLoader;
 pub use ssi::jwk::JWK;
-pub use ssi::ldp::resolve_key;
+pub use ssi::did_resolve::resolve_key;
 pub use ssi::ldp::ProofPreparation;
 pub use ssi::tzkey::jwk_from_tezos_key;
 pub use ssi::vc::get_verification_method;
@@ -35,7 +35,7 @@ pub use ssi::vc::Credential as VerifiableCredential;
 pub use ssi::vc::CredentialOrJWT;
 pub use ssi::vc::LinkedDataProofOptions;
 pub use ssi::vc::Presentation as VerifiablePresentation;
-pub use ssi::vc::ProofPurpose;
+pub use ssi::did::VerificationRelationship;
 pub use ssi::vc::VerificationResult;
 pub use ssi::vc::URI;
 pub use ssi::zcap::{Delegation, Invocation};
@@ -60,7 +60,7 @@ impl JWTOrLDPOptions {
     pub fn default_for_vp() -> Self {
         Self {
             ldp_options: LinkedDataProofOptions {
-                proof_purpose: Some(ProofPurpose::Authentication),
+                proof_purpose: Some(VerificationRelationship::Authentication),
                 ..Default::default()
             },
             proof_format: None,
@@ -112,8 +112,8 @@ pub enum GenerateProofError {
     #[cfg(not(any(feature = "wasm", target_os = "windows")))]
     #[error("Unable to sign: {0}")]
     Sign(#[from] crate::ssh_agent::SignError),
-    #[error("SSI: {0}")]
-    SSI(#[from] ssi::error::Error),
+    #[error("SSI Linked Data Proof: {0}")]
+    LDP(#[from] ssi::ldp::Error),
     #[error("IO: {0}")]
     IO(#[from] std::io::Error),
     #[error("WASM support for ssh-agent is not enabled")]
@@ -129,7 +129,7 @@ pub async fn generate_proof(
     resolver: &dyn DIDResolver,
     context_loader: &mut ContextLoader,
     ssh_agent_sock_path_opt: Option<&str>,
-) -> Result<ssi::vc::Proof, GenerateProofError> {
+) -> Result<ssi::ldp::Proof, GenerateProofError> {
     use ssi::ldp::LinkedDataProofs;
     let proof = match ssh_agent_sock_path_opt {
         #[cfg(feature = "wasm")]

--- a/lib/src/ssh_agent.rs
+++ b/lib/src/ssh_agent.rs
@@ -62,7 +62,7 @@ pub enum SignError {
     #[error("Unable to calculate JWK thumbprint: {0}")]
     JWKThumbprint(String),
     #[error("Unable to prepare proof: {0}")]
-    Prep(#[from] ssi::error::Error),
+    Prep(#[from] ssi::ldp::Error),
     #[error("RSA key must be at least 2048 bits")]
     RSAKeyTooSmall,
 }
@@ -308,7 +308,7 @@ pub async fn generate_proof(
     resolver: &dyn DIDResolver,
     context_loader: &mut ContextLoader,
     jwk_opt: Option<&JWK>,
-) -> Result<ssi::vc::Proof, SignError> {
+) -> Result<ssi::ldp::Proof, SignError> {
     let keys = list_keys(ssh_agent_sock).await?;
     let (jwk, pk) = select_key(keys, jwk_opt)?;
     let prep =

--- a/lib/web/Cargo.toml
+++ b/lib/web/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 serde_json = "1.0"
+thiserror = "1.0"
 js-sys = "0.3"
 getrandom = { version = "0.2", features = ["js"] }
 rand = { version = "0.7", features = ["wasm-bindgen"] }
@@ -16,7 +17,7 @@ chrono = { version = "0.4", features = ["wasmbind"] }
 [dependencies.didkit]
 path = "../"
 default-features = false
-features = ["wasm", "w3c"]
+features = ["wasm", "w3c", "tezos"]
 
 # TODO remove dependency on ssi
 [dependencies.ssi]

--- a/lib/web/Cargo.toml
+++ b/lib/web/Cargo.toml
@@ -16,23 +16,23 @@ chrono = { version = "0.4", features = ["wasmbind"] }
 [dependencies.didkit]
 path = "../"
 default-features = false
-features = ["wasm"]
+features = ["wasm", "w3c"]
 
 # TODO remove dependency on ssi
 [dependencies.ssi]
 path = "../../../ssi"
 default-features = false
-features = ["ed25519-dalek", "sha2", "rsa", "rand", "libsecp256k1", "p256"]
+features = ["w3c"]
 
 [dependencies.did-method-key]
 path = "../../../ssi/did-key"
 default-features = false
-features = ["secp256k1", "p256"]
+features = ["secp256k1", "secp256r1"]
 
 [dependencies.did-tz]
 path = "../../../ssi/did-tezos"
 default-features = false
-features = ["secp256k1", "dalek", "p256"]
+features = ["secp256k1", "ed25519", "secp256r1"]
 
 [dependencies.did-webkey]
 path = "../../../ssi/did-webkey"

--- a/lib/web/Cargo.toml
+++ b/lib/web/Cargo.toml
@@ -17,13 +17,13 @@ chrono = { version = "0.4", features = ["wasmbind"] }
 [dependencies.didkit]
 path = "../"
 default-features = false
-features = ["wasm", "w3c", "tezos"]
+features = ["wasm", "w3c", "tezos", "eip"]
 
 # TODO remove dependency on ssi
 [dependencies.ssi]
 path = "../../../ssi"
 default-features = false
-features = ["w3c"]
+features = ["w3c", "tezos", "eip"]
 
 [dependencies.did-method-key]
 path = "../../../ssi/did-key"

--- a/lib/web/src/lib.rs
+++ b/lib/web/src/lib.rs
@@ -503,7 +503,7 @@ pub fn DIDAuth(holder: String, linked_data_proof_options: String, key: String) -
 #[derive(thiserror::Error, Debug)]
 pub enum TezosJwkError {
     #[error(transparent)]
-    TzKey(#[from] ssi::tzkey::Error),
+    TzKey(#[from] ssi::tzkey::DecodeTezosPkError),
     #[error(transparent)]
     Json(#[from] serde_json::Error),
 }


### PR DESCRIPTION
we should at some point reconsider using `branch = "main"` for the `ssi` crate, any breaking changes pushed to main will break didkit builds everywhere. this pr just fixes builds for the latest update by changing imports and some types, users of the FFI libraries should not notice any breaking changes. notably this pr also slightly reorganises `src/lib/error.rs` to use `thiserror` and expands the set of features to match those of `ssi`. this should resolve #310 and #311 for now, but users will have to change their `p256` feature selection to `secp256r1`. This feature is also now a default.