### PR TITLE
Reduce CI time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         path: didkit
+        submodules: true
 
     - name: Checkout SSI library
       uses: actions/checkout@v3
@@ -100,13 +101,6 @@ jobs:
 
     - name: Test binary-signing verify example
       run: examples/binary-signing/index.sh verify examples/binary-signing/hello.txt examples/binary-signing/hello-vc.jsonld
-
-    - name: Checkout VC API Test Suite
-      uses: actions/checkout@v3
-      with:
-        repository: w3c-ccg/vc-api-test-suite
-        path: didkit/http/tests/vc-api/vc-api-test-suite
-        ref: 4923f0d627a223cd20a4ceb112336477ded445ca
 
     - name: Run VC API Test Suite
       working-directory: didkit/http/tests/vc-api

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,16 +34,7 @@ jobs:
         ref: ${{env.SSI_REF}}
         submodules: true
 
-    - name: Cache Cargo registry and build artifacts
-      uses: actions/cache@v3.0.11
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml', 'lib/Makefile', '**.rs') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
+    - uses: Swatinem/rust-cache@v2
 
     - name: Install Rust old stable with incremental compilation
       uses: actions-rs/toolchain@v1
@@ -53,10 +44,10 @@ jobs:
         default: true
 
     - name: Build
-      run: cargo build --verbose
+      run: cargo build
 
     - name: Test
-      run: cargo test --verbose
+      run: cargo test
 
     - name: Test CLI
       run: cli/tests/example.sh
@@ -180,16 +171,7 @@ jobs:
         ref: ${{env.SSI_REF}}
         submodules: true
 
-    - name: Cache Cargo registry and build artifacts
-      uses: actions/cache@v3.0.11
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml', 'lib/Makefile', '**.rs') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
+    - uses: Swatinem/rust-cache@v2
 
     - name: Install Rust iOS targets
       run: make -C lib install-rustup-ios
@@ -213,16 +195,7 @@ jobs:
         ref: ${{env.SSI_REF}}
         submodules: true
 
-    - name: Cache Cargo registry and build artifacts
-      uses: actions/cache@v3.0.11
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml', 'lib/Makefile', '**.rs') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
+    - uses: Swatinem/rust-cache@v2
 
     - name: Build
-      run: cargo build --verbose
+      run: cargo build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,31 +114,28 @@ jobs:
         npm install
         npm test
 
+    - name: Test C FFI
+      run: make -C lib ../target/test/c.stamp
+
     - name: Install wasm-pack
       run: make -C lib install-wasm-pack
+    - name: Compile WASM package
+      working-directory: didkit/lib/web
+      run: wasm-pack build --dev
 
     - name: Use system JDK
       run: echo "$JAVA_HOME/bin" >> $GITHUB_PATH
+    - name: Test JNI
+      run: make -C lib ../target/test/java.stamp
 
     - name: Install Flutter
       uses: subosito/flutter-action@v2
       with:
         channel: 'dev'
-
     - name: Opt out of Dart/Flutter analytics
       run: |
         dart --disable-analytics
         flutter --suppress-analytics config --no-analytics
-
-    - name: Test C FFI
-      run: make -C lib ../target/test/c.stamp
-
-    - name: Test WASM package
-      run: make -C lib ../target/test/wasm.stamp
-
-    - name: Test JNI
-      run: make -C lib ../target/test/java.stamp
-
     - name: Test Dart/Flutter plugin
       run: make -C lib ../target/test/flutter.stamp
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "http/tests/vc-api/vc-api-test-suite"]
+	path = http/tests/vc-api/vc-api-test-suite
+	url = https://github.com/clehner/vc-api-test-suite

--- a/http/tests/vc-api/.gitignore
+++ b/http/tests/vc-api/.gitignore
@@ -1,2 +1,1 @@
-vc-api-test-suite
 node_modules

--- a/http/tests/vc-api/README.md
+++ b/http/tests/vc-api/README.md
@@ -8,14 +8,8 @@ Requirements: [git][], [Cargo][] and [Node.js][].
 
 `didkit` and `ssi` should be checked out:
 ```sh
-git clone https://github.com/spruceid/didkit
+git clone https://github.com/spruceid/didkit --recurse-submodules
 git clone https://github.com/spruceid/ssi --recurse-submodules
-```
-
-Checkout the `vc-api` test server:
-```sh
-cd didkit/http/tests/vc-api
-git clone https://github.com/w3c-ccg/vc-api-test-suite --depth 1
 ```
 
 Install `npm` dependencies:

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -148,13 +148,6 @@ WEB_SRC=web/Cargo.toml $(wildcard web/src/*.rs)
 install-wasm-pack:
 	 curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-$(TARGET)/test/wasm.stamp: $(WEB_SRC) | $(TARGET)/test
-	cd web && wasm-pack build --target web --out-dir pkg/web
-	echo "No test was run"
-	# TODO write automated tests for at least Node.js, and maybe for the bundled output format.
-	# The existing web app installation didn't really make sense as the (dependency) installation has changed.
-	touch $@
-
 ## Cleanup
 
 .PHONY: clean

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -37,14 +37,17 @@ $(TARGET)/release/$(LIB_NAME): $(RUST_SRC)
 	cargo build --lib --release
 	strip $@ || true
 
+$(TARGET)/debug/$(LIB_NAME): $(RUST_SRC)
+	cargo build --lib
+
 ## C
 
-$(TARGET)/test/c.stamp: $(TARGET)/cabi-test $(TARGET)/release/$(LIB_NAME) | $(TARGET)/test
-	LD_LIBRARY_PATH=$(TARGET)/release $(TARGET)/cabi-test
+$(TARGET)/test/c.stamp: $(TARGET)/cabi-test $(TARGET)/debug/$(LIB_NAME) | $(TARGET)/test
+	LD_LIBRARY_PATH=$(TARGET)/debug $(TARGET)/cabi-test
 	touch $@
 
-$(TARGET)/cabi-test: c/test.c $(TARGET)/release/$(LIB_NAME) $(TARGET)/didkit.h
-	$(CC) -I$(TARGET) -L$(TARGET)/release $< -ldl -ldidkit -o $@
+$(TARGET)/cabi-test: c/test.c $(TARGET)/debug/$(LIB_NAME) $(TARGET)/didkit.h
+	$(CC) -I$(TARGET) -L$(TARGET)/debug $< -ldl -ldidkit -o $@
 
 ## Java
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -57,9 +57,9 @@ $(TARGET)/test/java.stamp: \
 	$(TARGET)/jvm/com/spruceid/DIDKit.class \
 	$(TARGET)/jvm/com/spruceid/DIDKitException.class \
 	$(TARGET)/jvm/com/spruceid/DIDKitTest.class \
-	$(TARGET)/release/$(LIB_NAME) | $(TARGET)/test
+	$(TARGET)/debug/$(LIB_NAME) | $(TARGET)/test
 	java -Djava.class.path=$(TARGET)/jvm \
-		-Djava.library.path=$(TARGET)/release \
+		-Djava.library.path=$(TARGET)/debug \
 		com.spruceid.DIDKitTest
 	touch $@
 


### PR DESCRIPTION
Attempt to reduce the CI time by using debug mode instead of release. In the end, iOS and Flutter are still using release so it's still around 30min -- but because they are using symlinks they require large refactors (using LD_PATHS does not work with either) I plan to address it in following PRs.