### PR TITLE
Remove dependency on macros package from c api

### DIFF
--- a/lib/src/c.rs
+++ b/lib/src/c.rs
@@ -411,7 +411,7 @@ fn vc_verify_credential(
             &mut ctx,
         )),
         ProofFormat::LDP => {
-            let vc = VerifiableCredential::from_json_unsigned(&vc_str)?;
+            let vc = VerifiableCredential::from_json_unsigned(vc_str)?;
             rt.block_on(vc.verify(Some(proof_options.ldp_options), resolver, &mut ctx))
         }
     };
@@ -667,7 +667,7 @@ pub extern "C" fn didkit_create_context(
             string_from_raw_ptr(json_ptr).map(|json| (url, json))
         )
         .map(|(url, json)| Context{url, json})
-        .and_then(|ctx| to_bas64_json_raw_ptr(&ctx))
+        .and_then(to_bas64_json_raw_ptr)
         .unwrap_or_else(stash_err)
 }
 
@@ -677,7 +677,7 @@ pub extern "C" fn didkit_create_context_map(
     size: usize,
 ) -> *const c_char {
     string_vec_from_string_array_raw_ptr(contexts_ptr, size)
-        .and_then(|ctx| to_bas64_json_raw_ptr(&ctx))
+        .and_then(to_bas64_json_raw_ptr)
         .unwrap_or_else(stash_err)
 }
 

--- a/lib/src/c.rs
+++ b/lib/src/c.rs
@@ -292,14 +292,14 @@ fn vc_issue_credential(
                 .map_err(Error::from)
         }
         ProofFormat::LDP => {
-            let mut ctx = context_loader.clone();
+            let mut ctx = context_loader;
             let proof = rt.block_on(credential.generate_proof(
                 &jwk,
                 &proof_options.ldp_options,
                 resolver,
                 &mut ctx,
             ))?;
-            let mut cred_with_proof = credential.clone();
+            let mut cred_with_proof = credential;
             cred_with_proof.add_proof(proof);
             serde_json::to_string(&cred_with_proof).map_err(Error::from)
         }
@@ -349,7 +349,7 @@ fn vc_verify_credential(
     let proof_format = proof_options.proof_format.unwrap_or_default();
     let rt = runtime::get()?;
     let resolver = DID_METHODS.to_resolver();
-    let mut ctx = context_loader.clone();
+    let mut ctx = context_loader;
     let vr = match proof_format {
         ProofFormat::JWT => rt.block_on(VerifiableCredential::verify_jwt(
             vc_str,
@@ -417,14 +417,14 @@ fn vc_issue_presentation(
             ).map_err(Error::from)
         }
         ProofFormat::LDP => {
-            let mut ctx = context_loader.clone();
+            let mut ctx = context_loader;
             let proof = rt.block_on(presentation.generate_proof(
                 &jwk,
                 &proof_options.ldp_options,
                 resolver,
                 &mut ctx
             ))?;
-            let mut presentation_with_proof = presentation.clone();
+            let mut presentation_with_proof = presentation;
             presentation_with_proof.add_proof(proof);
             serde_json::to_string(&presentation_with_proof).map_err(Error::from)
         }
@@ -476,7 +476,7 @@ fn vc_verify_presentation(
     let proof_format = proof_options.proof_format.unwrap_or_default();
     let rt = runtime::get()?;
     let resolver = DID_METHODS.to_resolver();
-    let mut ctx = context_loader.clone();
+    let mut ctx = context_loader;
     let vr = match proof_format {
         ProofFormat::JWT => rt.block_on(VerifiablePresentation::verify_jwt(
             vp_str,
@@ -556,7 +556,7 @@ fn did_auth(
             ).map_err(Error::from)
         }
         ProofFormat::LDP => {
-            let mut ctx = context_loader.clone();
+            let mut ctx = context_loader;
             let proof = rt.block_on(presentation.generate_proof(
                 &jwk,
                 &proof_options.ldp_options,
@@ -756,7 +756,7 @@ fn vc_prepare_issue_credential(
 ) -> Result<ProofPreparation, Error> {
     let resolver = DID_METHODS.to_resolver();
     let rt = runtime::get()?;
-    let mut ctx = context_loader.clone();
+    let mut ctx = context_loader;
     rt.block_on(credential.prepare_proof(
         &jwk,
         &linked_data_proof_options,
@@ -807,7 +807,7 @@ fn vc_complete_issue_credential(
 ) -> Result<VerifiableCredential, Error> {
     let rt = runtime::get()?;
     let proof = rt.block_on(preparation.proof.type_.complete(&preparation, &signature))?;
-    let mut credential_with_proof = credential.clone();
+    let mut credential_with_proof = credential;
     credential_with_proof.add_proof(proof);
     Ok(credential_with_proof)
 }
@@ -859,7 +859,7 @@ fn vc_prepare_issue_presentation(
 ) -> Result<ProofPreparation, Error> {
     let resolver = DID_METHODS.to_resolver();
     let rt = runtime::get()?;
-    let mut ctx = context_loader.clone();
+    let mut ctx = context_loader;
     rt.block_on(presentation.prepare_proof(
         &jwk,
         &linked_data_proof_options,
@@ -909,7 +909,7 @@ fn vc_complete_issue_presentation(
 ) -> Result<VerifiablePresentation, Error> {
     let rt = runtime::get()?;
     let proof = rt.block_on(preparation.proof.type_.complete(&preparation, &signature))?;
-    let mut presentation_with_proof = presentation.clone();
+    let mut presentation_with_proof = presentation;
     presentation_with_proof.add_proof(proof);
     Ok(presentation_with_proof)
 }

--- a/lib/src/c.rs
+++ b/lib/src/c.rs
@@ -44,7 +44,6 @@ where
         .and_then(to_char_raw_ptr)
 }
 
-
 fn to_char_raw_ptr<T>(value: T) -> Result<*const c_char, Error>
 where
     T: Into<Vec<u8>>
@@ -52,10 +51,6 @@ where
     CString::new(value).map_err(Error::from)
         .map(|s| s.into_raw() as *const c_char)
 }
-
-// fn str_to_raw_ptr(value: &str) -> Result<*const c_char, Error> {
-//     to_char_raw_ptr(value)
-// }
 
 fn string_to_raw_ptr(value: String) -> Result<*const c_char, Error> {
     to_char_raw_ptr(value)
@@ -141,7 +136,6 @@ fn dereferencing_input_metadata_from_raw_ptr(
         .and_then(|s| serde_json::from_str(&s).map_err(Error::from))
 }
 
-
 /// Calls a rust function with two arguments marshalled from C
 ///
 /// # Arguments
@@ -166,8 +160,7 @@ where
     enc_fun(rust_val)
 }
 
-
-/// Calls a rust function with two arguments marshalled from C
+/// Calls a rust function with three arguments marshalled from C
 ///
 /// # Arguments
 /// * `arg_one_res` The result we will extract a value from for the first arg to rust_fun
@@ -194,9 +187,7 @@ where
     enc_fun(rust_val)
 }
 
-
-
-/// Calls a rust function with two arguments marshalled from C
+/// Calls a rust function with four arguments marshalled from C
 ///
 /// # Arguments
 /// * `arg_one_res` The result we will extract a value from for the first arg to rust_fun
@@ -327,7 +318,6 @@ fn key_to_verification_method(
         .ok_or(Error::UnableToGetVerificationMethod)
 }
 
-
 /// Issue a Verifiable Credential. Input parameters are JSON C strings for the unsigned credential
 /// to be issued, the linked data proof options, and the JWK for signing.  On success, the
 /// newly-issued verifiable credential is returned as a newly-allocated C string.  The returned
@@ -349,8 +339,6 @@ pub extern "C" fn didkit_vc_issue_credential(
         to_char_raw_ptr
     ).unwrap_or_else(stash_err)
 }
-
-
 
 fn vc_issue_credential(
     credential: VerifiableCredential,
@@ -381,7 +369,6 @@ fn vc_issue_credential(
         }
     }
 }
-
 
 /// Verify a Verifiable Credential. Arguments are a C string containing the Verifiable Credential to
 /// verify, and a C string containing a JSON object for the linked data proof options for
@@ -430,7 +417,6 @@ fn vc_verify_credential(
     };
     Ok(vr)
 }
-
 
 /// Issue a Verifiable Presentation. Input parameters are JSON C strings for the unsigned
 /// presentation to be issued, the linked data proof options, and the JWK for signing. On success,
@@ -484,8 +470,6 @@ fn vc_issue_presentation(
     }
 }
 
-
-
 /// Verify a Verifiable Presentation. Arguments are a C string containing the Verifiable
 /// Presentation to verify, and a C string containing a JSON object for the linked data proof
 /// options for verification. The return value is a newly-allocated C string containing a JSON
@@ -509,7 +493,6 @@ pub extern "C" fn didkit_vc_verify_presentation(
         to_json_raw_ptr
     ).unwrap_or_else(stash_err)
 }
-
 
 fn vc_verify_presentation(
     vp_str: &str,
@@ -563,7 +546,6 @@ pub extern "C" fn didkit_did_auth(
     ).unwrap_or_else(stash_err)
 }
 
-
 fn did_auth(
     holder: String,
     proof_options: JWTOrLDPOptions,
@@ -616,7 +598,6 @@ pub extern "C" fn didkit_resolve_did(
     ).unwrap_or_else(stash_err)
 }
 
-
 fn resolve_did(
     did: &str,
     input_metadata: ResolutionInputMetadata
@@ -632,7 +613,6 @@ fn resolve_did(
     };
     Ok(res_result)
 }
-
 
 /// Resolve a DID to a DID Document. Arguments are a C string containing the DID URL to dereference,
 /// and a C string containing a JSON object for dereferencing input metadata. The return value on
@@ -652,7 +632,6 @@ pub extern "C" fn didkit_dereference_did_url(
     ).unwrap_or_else(stash_err)
 }
 
-
 fn dereference_did_url(
     did_url: &str,
     input_metadata: DereferencingInputMetadata
@@ -664,7 +643,6 @@ fn dereference_did_url(
     let result = json!(deref_result);
     serde_json::to_string(&result).map_err(Error::from)
 }
-
 
 #[derive(Serialize, Deserialize)]
 struct Context {
@@ -692,7 +670,6 @@ pub extern "C" fn didkit_create_context(
         .and_then(|ctx| to_bas64_json_raw_ptr(&ctx))
         .unwrap_or_else(stash_err)
 }
-
 
 #[no_mangle]
 pub extern "C" fn didkit_create_context_map(
@@ -725,8 +702,6 @@ fn load_context(context_loader_ptr: *const c_char) -> Result<ssi::jsonld::Contex
     }
 }
 
-
-
 /// Prepares a credential for signing by an external service.
 ///
 /// All parameters are pointers to json encoded strings.
@@ -751,7 +726,6 @@ pub extern "C" fn didkit_vc_prepare_issue_credential(
     ).unwrap_or_else(stash_err)
 }
 
-
 /// Prepares a credential for signing by an external service.
 fn vc_prepare_issue_credential(
     credential: VerifiableCredential,
@@ -769,7 +743,6 @@ fn vc_prepare_issue_credential(
         &mut ctx,
     )).map_err(Error::from)
 }
-
 
 /// Completes credential issuance after obtaining a signature from an external service.
 ///
@@ -795,7 +768,6 @@ pub extern "C" fn didkit_vc_complete_issue_credential(
     ).unwrap_or_else(stash_err)
 }
 
-
 fn vc_complete_issue_credential(
     credential: VerifiableCredential,
     preparation: ProofPreparation,
@@ -807,7 +779,6 @@ fn vc_complete_issue_credential(
     credential_with_proof.add_proof(proof);
     Ok(credential_with_proof)
 }
-
 
 #[no_mangle]
 pub extern "C" fn didkit_vc_prepare_issue_presentation(
@@ -825,8 +796,6 @@ pub extern "C" fn didkit_vc_prepare_issue_presentation(
         to_json_raw_ptr
     ).unwrap_or_else(stash_err)
 }
-
-
 
 /// Prepares a presentation for signing by an external service.
 ///
@@ -887,7 +856,6 @@ fn vc_complete_issue_presentation(
     presentation_with_proof.add_proof(proof);
     Ok(presentation_with_proof)
 }
-
 
 // TODO: didkit_delegate_capability
 // TODO: didkit_prepare_delegate_capability

--- a/lib/src/c.rs
+++ b/lib/src/c.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 use std::ffi::CStr;
 use std::ffi::CString;
-use std::os::raw::{c_char, c_uint};
+use std::os::raw::{c_char};
 use std::ptr;
 
 use serde::{Deserialize, Serialize};
-use ssi::ldp::{ProofPreparation, ProofSuite};
+use ssi::ldp::{ProofPreparation, ProofSuite, VerificationResult};
 use ssi::vc::LinkedDataProofOptions;
 
 use crate::error::Error;
@@ -31,52 +31,148 @@ pub extern "C" fn didkit_get_version() -> *const c_char {
     VERSION_C.as_ptr() as *const c_char
 }
 
-fn ccchar_or_error(result: Result<*const c_char, Error>) -> *const c_char {
-    // On success, pass through the string. On error, save the error for retrieval using
-    // didkit_error_message, and return NULL.
-    match result {
-        Ok(ccchar) => ccchar,
-        Err(error) => {
-            error.stash();
-            ptr::null()
-        }
+fn stash_err(error: Error) -> *const c_char {
+    error.stash();
+    ptr::null()
+}
+
+fn to_json_raw_ptr<T>(value: &T) -> Result<*const c_char, Error>
+where
+    T: ?Sized + Serialize
+{
+    serde_json::to_string(value).map_err(Error::from)
+        .and_then(to_char_raw_ptr)
+}
+
+
+fn to_char_raw_ptr<T>(value: T) -> Result<*const c_char, Error>
+where
+    T: Into<Vec<u8>>
+{
+    CString::new(value).map_err(Error::from)
+        .map(|s| s.into_raw() as *const c_char)
+}
+
+fn to_bas64_json_raw_ptr<T>(value: &T) -> Result<*const c_char, Error>
+where
+    T: ?Sized + Serialize
+{
+    serde_json::to_string(value).map_err(Error::from)
+        .map(base64::encode)
+        .and_then(to_char_raw_ptr)
+}
+
+fn string_from_raw_ptr(c_str: *const c_char) -> Result<String, Error> {
+    unsafe{ CStr::from_ptr(c_str) }
+        .to_str() //to_str() copies the bytes from c_str
+        .map(String::from)
+        .map_err(Error::from)
+}
+
+fn str_from_raw_ptr<'a>(c_str: *const c_char) -> Result<&'a str, Error> {
+    unsafe{ CStr::from_ptr(c_str) }
+        .to_str() //to_str() copies the bytes from c_str
+        .map_err(Error::from)
+}
+
+fn string_or_default_from_raw_ptr(c_str: *const c_char, default: &str) -> Result<String, Error> {
+    if c_str.is_null() {
+        Ok(default.to_string())
+    } else {
+        string_from_raw_ptr(c_str)
     }
 }
+
+fn string_vec_from_string_array_raw_ptr(
+    string_array_ptr: *const *const c_char,
+    size: usize
+) -> Result<Vec<String>, Error> {
+    let mut string_vec: Vec<String> = Vec::with_capacity(size);
+    for i in 0..size as isize {
+        let cur_string_ptr = unsafe { string_array_ptr.offset(i) };
+        let string = unsafe { string_from_raw_ptr(cur_string_ptr.read())? };
+        string_vec.push(string);
+    }
+    Ok(string_vec)
+}
+
+fn from_json_raw_ptr<'a, T>(json_ptr: *const c_char) -> Result<T, Error>
+where
+    T:Deserialize<'a>
+{
+    str_from_raw_ptr(json_ptr)
+        .and_then(|s| serde_json::from_str(s).map_err(Error::from))
+}
+
+/// We use VerifiablePresentation's json deserializer, instead of the generic serde one
+fn presentation_from_raw_ptr(
+    presentation_json_ptr: *const c_char
+) -> Result<VerifiablePresentation, Error> {
+    string_from_raw_ptr(presentation_json_ptr)
+        .and_then(
+            |s|
+            VerifiablePresentation::from_json_unsigned(&s).map_err(Error::from)
+        )
+}
+
+/// input_metadata has special default string handling, so we can't use the generic
+/// from_json_raw_ptr
+fn input_metadata_from_raw_ptr(
+    input_metadata_json_ptr: *const c_char
+) -> Result<ResolutionInputMetadata, Error> {
+    string_or_default_from_raw_ptr(input_metadata_json_ptr, "{}")
+        .and_then(|s| serde_json::from_str(&s).map_err(Error::from))
+}
+
+/// dereferencing_input_metadata has special default string handling, so we can't use the generic
+/// from_json_raw_ptr
+fn dereferencing_input_metadata_from_raw_ptr(
+    input_metadata_json_ptr: *const c_char
+) -> Result<DereferencingInputMetadata, Error> {
+    string_or_default_from_raw_ptr(input_metadata_json_ptr, "{}")
+        .and_then(|s| serde_json::from_str(&s).map_err(Error::from))
+}
+
 
 /// Generate a new Ed25519 keypair in JWK format. On success, returns a pointer to a
 /// newly-allocated string containing the JWK. The string must be freed with [`didkit_free_string`]. On
 /// failure, returns `NULL`; the error message can be retrieved with [`didkit_error_message`].
-#[didkit_macros::c_export(wrap = "ccchar_or_error")]
-fn didkit_generate_ed25519_key() -> Result<*const c_char, Error> {
-    let jwk = JWK::generate_ed25519()?;
-    Ok(CString::new(serde_json::to_string(&jwk)?)?.into_raw())
+#[no_mangle]
+pub extern "C" fn didkit_generate_ed25519_key() -> *const c_char {
+    JWK::generate_ed25519().map_err(Error::from)
+        .and_then(|jwk| to_json_raw_ptr(&jwk))
+        .unwrap_or_else(stash_err)
+
 }
 
 /// Generate a new secp256r1 keypair in JWK format. On success, returns a pointer to a
 /// newly-allocated string containing the JWK. The string must be freed with [`didkit_free_string`]. On
 /// failure, returns `NULL`; the error message can be retrieved with [`didkit_error_message`].
-#[didkit_macros::c_export(wrap = "ccchar_or_error")]
-fn didkit_generate_secp256r1_key() -> Result<*const c_char, Error> {
-    let jwk = JWK::generate_p256()?;
-    Ok(CString::new(serde_json::to_string(&jwk)?)?.into_raw())
+#[no_mangle]
+pub extern "C" fn didkit_generate_secp256r1_key() -> *const c_char {
+    JWK::generate_p256().map_err(Error::from)
+        .and_then(|jwk| to_json_raw_ptr(&jwk))
+        .unwrap_or_else(stash_err)
 }
 
 /// Generate a new secp256k1 keypair in JWK format. On success, returns a pointer to a
 /// newly-allocated string containing the JWK. The string must be freed with [`didkit_free_string`]. On
 /// failure, returns `NULL`; the error message can be retrieved with [`didkit_error_message`].
-#[didkit_macros::c_export(wrap = "ccchar_or_error")]
-fn didkit_generate_secp256k1_key() -> Result<*const c_char, Error> {
-    let jwk = JWK::generate_secp256k1()?;
-    Ok(CString::new(serde_json::to_string(&jwk)?)?.into_raw())
+#[no_mangle]
+pub extern "C" fn didkit_generate_secp256k1_key() -> *const c_char {
+    JWK::generate_secp256k1().map_err(Error::from)
+        .and_then(|jwk| to_json_raw_ptr(&jwk))
+        .unwrap_or_else(stash_err)
 }
 
 /// Generate a new secp384r1 keypair in JWK format. On success, returns a pointer to a
 /// newly-allocated string containing the JWK. The string must be freed with [`didkit_free_string`]. On
 /// failure, returns `NULL`; the error message can be retrieved with [`didkit_error_message`].
-#[didkit_macros::c_export(wrap = "ccchar_or_error")]
-fn didkit_generate_secp384r1_key() -> Result<*const c_char, Error> {
-    let jwk = JWK::generate_p384()?;
-    Ok(CString::new(serde_json::to_string(&jwk)?)?.into_raw())
+#[no_mangle]
+pub extern "C" fn didkit_generate_secp384r1_key() -> *const c_char {
+    JWK::generate_p384().map_err(Error::from)
+        .and_then(|jwk| to_json_raw_ptr(&jwk))
+        .unwrap_or_else(stash_err)
 }
 
 /// Convert a key in JWK format to a did:key DID. Input should be a JWK containing public key
@@ -85,245 +181,392 @@ fn didkit_generate_secp384r1_key() -> Result<*const c_char, Error> {
 /// freed
 /// with [`didkit_free_string`].  On failure, returns `NULL`; the error message can be retrieved
 /// with [`didkit_error_message`].
-#[didkit_macros::c_export(wrap = "ccchar_or_error")]
-fn didkit_key_to_did(
+#[no_mangle]
+pub extern "C" fn didkit_key_to_did(
     method_pattern_ptr: *const c_char,
     key_json_ptr: *const c_char,
-) -> Result<*const c_char, Error> {
-    let method_pattern = unsafe { CStr::from_ptr(method_pattern_ptr) }.to_str()?;
-    let key_json = unsafe { CStr::from_ptr(key_json_ptr) }.to_str()?;
-    let key: JWK = serde_json::from_str(key_json)?;
-    let did = DID_METHODS
-        .generate(&Source::KeyAndPattern(&key, method_pattern))
-        .ok_or(Error::UnableToGenerateDID)?;
-    Ok(CString::new(did)?.into_raw())
+) -> *const c_char {
+    string_from_raw_ptr(method_pattern_ptr)
+        .and_then(
+            |method_pattern|
+            from_json_raw_ptr::<JWK>(key_json_ptr).map(|jwk| (method_pattern, jwk))
+        )
+        .and_then(|(method_pattern, jwk)| key_to_did(&method_pattern, &jwk))
+        .and_then(to_char_raw_ptr)
+        .unwrap_or_else(stash_err)
 }
 
-/// Convert a key to a `did:key` DID URI for use in the `verificationMethod` property of a linked data
-/// proof. Input should be a C string containing the key as a JWK. The JWK should contain public
-/// key material; private key parameters are ignored. On success, this function returns a newly-allocated C string containing the `verificationMethod` URI. On failure, `NULL` is returned; the
-/// error message can be retrieved using [`didkit_error_message`].
-#[didkit_macros::c_export(wrap = "ccchar_or_error")]
-fn didkit_key_to_verification_method(
+fn key_to_did(method_pattern: &str, jwk: &JWK) -> Result<String, Error> {
+    DID_METHODS
+        .generate(&Source::KeyAndPattern(jwk, method_pattern))
+        .ok_or(Error::UnableToGenerateDID)
+}
+
+/// Convert a key to a `did:key` DID URI for use in the `verificationMethod` property of a linked
+/// data proof. Input should be a C string containing the key as a JWK. The JWK should contain
+/// public key material; private key parameters are ignored. On success, this function returns a
+/// newly-allocated C string containing the `verificationMethod` URI. On failure, `NULL` is
+/// returned; the error message can be retrieved using [`didkit_error_message`].
+#[no_mangle]
+pub extern "C" fn didkit_key_to_verification_method(
     method_pattern_ptr: *const c_char,
     key_json_ptr: *const c_char,
-) -> Result<*const c_char, Error> {
-    let method_pattern = unsafe { CStr::from_ptr(method_pattern_ptr) }.to_str()?;
-    let key_json = unsafe { CStr::from_ptr(key_json_ptr) }.to_str()?;
-    let key: JWK = serde_json::from_str(key_json)?;
+) -> *const c_char {
+    string_from_raw_ptr(method_pattern_ptr)
+        .and_then(
+            |method_pattern|
+            from_json_raw_ptr::<JWK>(key_json_ptr)
+                .map(|jwk| (method_pattern, jwk))
+        )
+        .and_then(|(method_pattern, jwk)| key_to_verification_method(&method_pattern, jwk))
+        .and_then(to_char_raw_ptr)
+        .unwrap_or_else(stash_err)
+}
+
+fn key_to_verification_method(
+    method_pattern: &str,
+    jwk: JWK
+) -> Result<String, Error> {
     let did_method = DID_METHODS
         .get(method_pattern)
         .ok_or(Error::UnknownDIDMethod)?;
     let did = did_method
-        .generate(&Source::Key(&key))
+        .generate(&Source::Key(&jwk))
         .ok_or(Error::UnableToGenerateDID)?;
     let did_resolver = did_method.to_resolver();
     let rt = runtime::get()?;
-    let vm = rt
-        .block_on(get_verification_method(&did, did_resolver))
-        .ok_or(Error::UnableToGetVerificationMethod)?;
-    Ok(CString::new(vm)?.into_raw())
+    rt.block_on(get_verification_method(&did, did_resolver))
+        .ok_or(Error::UnableToGetVerificationMethod)
 }
+
 
 /// Issue a Verifiable Credential. Input parameters are JSON C strings for the unsigned credential
 /// to be issued, the linked data proof options, and the JWK for signing.  On success, the
 /// newly-issued verifiable credential is returned as a newly-allocated C string.  The returned
-/// string should be freed using [`didkit_free_string`]. On failure, `NULL` is returned, and the error
-/// message can be retrieved using [`didkit_error_message`].
-#[didkit_macros::c_export(wrap = "ccchar_or_error")]
-fn didkit_vc_issue_credential(
+/// string should be freed using [`didkit_free_string`]. On failure, `NULL` is returned, and the
+/// error message can be retrieved using [`didkit_error_message`].
+#[no_mangle]
+pub extern "C" fn didkit_vc_issue_credential(
     credential_json_ptr: *const c_char,
     proof_options_json_ptr: *const c_char,
     key_json_ptr: *const c_char,
     context_loader_ptr: *const c_char,
-) -> Result<*const c_char, Error> {
-    let resolver = DID_METHODS.to_resolver();
-    let mut context_loader = load_context(context_loader_ptr)?;
-    let credential_json = unsafe { CStr::from_ptr(credential_json_ptr) }.to_str()?;
-    let proof_options_json = unsafe { CStr::from_ptr(proof_options_json_ptr) }.to_str()?;
-    let key_json = unsafe { CStr::from_ptr(key_json_ptr) }.to_str()?;
-    let mut credential = VerifiableCredential::from_json_unsigned(credential_json)?;
-    let key: JWK = serde_json::from_str(key_json)?;
-    let options: JWTOrLDPOptions = serde_json::from_str(proof_options_json)?;
-    let proof_format = options.proof_format.unwrap_or_default();
-    let rt = runtime::get()?;
-    let out = match proof_format {
-        ProofFormat::JWT => {
-            rt.block_on(credential.generate_jwt(Some(&key), &options.ldp_options, resolver))?
-        }
-        ProofFormat::LDP => {
-            let proof = rt.block_on(credential.generate_proof(
-                &key,
-                &options.ldp_options,
-                resolver,
-                &mut context_loader,
-            ))?;
-            credential.add_proof(proof);
-            serde_json::to_string(&credential)?
-        }
-    };
-    Ok(CString::new(out)?.into_raw())
+) -> *const c_char {
+    from_json_raw_ptr::<VerifiableCredential>(credential_json_ptr)
+        .and_then(
+            |credential|
+            from_json_raw_ptr::<JWTOrLDPOptions>(proof_options_json_ptr)
+                .map(|proof_options| (credential, proof_options))
+        )
+        .and_then(
+            |(credential, proof_options)|
+            from_json_raw_ptr::<JWK>(key_json_ptr)
+                .map(|jwk| (credential, proof_options, jwk))
+        )
+        .and_then(
+            |(credential, proof_options, jwk)|
+            load_context(context_loader_ptr)
+                .map(|context| (credential, proof_options, jwk, context))
+        )
+        .and_then(
+            |(credential, proof_options, jwk, context)|
+            vc_issue_credential(credential, proof_options, jwk, context)
+        )
+        .and_then(to_char_raw_ptr)
+        .unwrap_or_else(stash_err)
 }
 
-/// Verify a Verifiable Credential. Arguments are a C string containing the Verifiable Credential
-/// to verify, and a C string containing a JSON object for the linked data proof options for
+fn vc_issue_credential(
+    credential: VerifiableCredential,
+    proof_options: JWTOrLDPOptions,
+    jwk: JWK,
+    context_loader: ssi::jsonld::ContextLoader
+) -> Result<String, Error> {
+    let resolver = DID_METHODS.to_resolver();
+    let proof_format = proof_options.proof_format.unwrap_or_default();
+    let rt = runtime::get()?;
+    match proof_format {
+        ProofFormat::JWT => {
+            rt
+                .block_on(credential.generate_jwt(Some(&jwk), &proof_options.ldp_options, resolver))
+                .map_err(Error::from)
+        }
+        ProofFormat::LDP => {
+            let mut ctx = context_loader.clone();
+            let proof = rt.block_on(credential.generate_proof(
+                &jwk,
+                &proof_options.ldp_options,
+                resolver,
+                &mut ctx,
+            ))?;
+            let mut cred_with_proof = credential.clone();
+            cred_with_proof.add_proof(proof);
+            serde_json::to_string(&cred_with_proof).map_err(Error::from)
+        }
+    }
+}
+
+
+/// Verify a Verifiable Credential. Arguments are a C string containing the Verifiable Credential to
+/// verify, and a C string containing a JSON object for the linked data proof options for
 /// verification. The return value is a newly-allocated C string containing a JSON object for the
 /// verification result, or `NULL` in case of certain errors. On successful verification, the
 /// verification result JSON object contains a "errors" property whose value is an empty array. If
 /// verification fails, either `NULL` is returned and the error can be retrieved using
-/// [`didkit_error_message`], or a verification result JSON object is returned with an "errors" array
-/// containing information about the verification error(s) encountered. A string returned from this
-/// function should be freed using [`didkit_free_string`].
-#[didkit_macros::c_export(wrap = "ccchar_or_error")]
-fn didkit_vc_verify_credential(
-    credential_ptr: *const c_char,
+/// [`didkit_error_message`], or a verification result JSON object is returned with an "errors"
+/// array containing information about the verification error(s) encountered. A string returned from
+/// this function should be freed using [`didkit_free_string`].
+#[no_mangle]
+pub extern "C" fn didkit_vc_verify_credential(
+    vc_str_ptr: *const c_char,
     proof_options_json_ptr: *const c_char,
     context_loader_ptr: *const c_char,
-) -> Result<*const c_char, Error> {
-    let vc_str = unsafe { CStr::from_ptr(credential_ptr) }.to_str()?;
-    let proof_options_json = unsafe { CStr::from_ptr(proof_options_json_ptr) }.to_str()?;
-    let options: JWTOrLDPOptions = serde_json::from_str(proof_options_json)?;
-    let proof_format = options.proof_format.unwrap_or_default();
+) -> *const c_char {
+    string_from_raw_ptr(vc_str_ptr)
+        .and_then(
+            |vc_str|
+            from_json_raw_ptr::<JWTOrLDPOptions>(proof_options_json_ptr)
+                .map(|proof_options| (vc_str, proof_options))
+        )
+        .and_then(
+            |(vc_str, proof_options)|
+            load_context(context_loader_ptr)
+                .map(|context| (vc_str, proof_options, context))
+        )
+        .and_then(
+            |(vc_str, proof_options, context)|
+            vc_verify_credential(&vc_str, proof_options, context)
+        )
+        .and_then(|verification_result| to_json_raw_ptr(&verification_result))
+        .unwrap_or_else(stash_err)
+}
+
+fn vc_verify_credential(
+    vc_str: &str,
+    proof_options: JWTOrLDPOptions,
+    context_loader: ssi::jsonld::ContextLoader
+) -> Result<VerificationResult, Error> {
+    let proof_format = proof_options.proof_format.unwrap_or_default();
     let rt = runtime::get()?;
     let resolver = DID_METHODS.to_resolver();
-    let mut context_loader = load_context(context_loader_ptr)?;
-    let result = match proof_format {
+    let mut ctx = context_loader.clone();
+    let vr = match proof_format {
         ProofFormat::JWT => rt.block_on(VerifiableCredential::verify_jwt(
             vc_str,
-            Some(options.ldp_options),
+            Some(proof_options.ldp_options),
             resolver,
-            &mut context_loader,
+            &mut ctx,
         )),
         ProofFormat::LDP => {
             let vc = VerifiableCredential::from_json_unsigned(vc_str)?;
-            rt.block_on(vc.verify(Some(options.ldp_options), resolver, &mut context_loader))
+            rt.block_on(vc.verify(Some(proof_options.ldp_options), resolver, &mut ctx))
         }
     };
-    Ok(CString::new(serde_json::to_string(&result)?)?.into_raw())
+    Ok(vr)
 }
+
 
 /// Issue a Verifiable Presentation. Input parameters are JSON C strings for the unsigned
 /// presentation to be issued, the linked data proof options, and the JWK for signing. On success,
-/// the newly-issued verifiable presentation is returned as a newly-allocated C string. The
-/// returned string should be freed using [`didkit_free_string`]. On failure, `NULL` is returned, and the
+/// the newly-issued verifiable presentation is returned as a newly-allocated C string. The returned
+/// string should be freed using [`didkit_free_string`]. On failure, `NULL` is returned, and the
 /// error message can be retrieved using [`didkit_error_message`].
-#[didkit_macros::c_export(wrap = "ccchar_or_error")]
-fn didkit_vc_issue_presentation(
+#[no_mangle]
+pub extern "C" fn didkit_vc_issue_presentation(
     presentation_json_ptr: *const c_char,
     proof_options_json_ptr: *const c_char,
     key_json_ptr: *const c_char,
     context_loader_ptr: *const c_char,
-) -> Result<*const c_char, Error> {
+) -> *const c_char {
+    presentation_from_raw_ptr(presentation_json_ptr)
+        .and_then(
+            |presentation|
+            from_json_raw_ptr::<JWTOrLDPOptions>(proof_options_json_ptr)
+                .map(|proof_options| (presentation, proof_options))
+        )
+        .and_then(
+            |(presentation, proof_options)|
+            from_json_raw_ptr::<JWK>(key_json_ptr).map(|jwk| (presentation, proof_options, jwk))
+        )
+        .and_then(
+            |(presentation, proof_options, jwk)|
+            load_context(context_loader_ptr)
+                .map(|context_loader| (presentation, proof_options, jwk, context_loader))
+        )
+        .and_then(
+            |(presentation, proof_options, jwk, context_loader)|
+            vc_issue_presentation(presentation, proof_options, jwk, context_loader)
+        )
+        .and_then(to_char_raw_ptr)
+        .unwrap_or_else(stash_err)
+}
+
+fn vc_issue_presentation(
+    presentation: VerifiablePresentation,
+    proof_options: JWTOrLDPOptions,
+    jwk: JWK,
+    context_loader: ssi::jsonld::ContextLoader
+) -> Result<String, Error> {
     let resolver = DID_METHODS.to_resolver();
-    let mut context_loader = load_context(context_loader_ptr)?;
-    let presentation_json = unsafe { CStr::from_ptr(presentation_json_ptr) }.to_str()?;
-    let proof_options_json = unsafe { CStr::from_ptr(proof_options_json_ptr) }.to_str()?;
-    let key_json = unsafe { CStr::from_ptr(key_json_ptr) }.to_str()?;
-    let mut presentation = VerifiablePresentation::from_json_unsigned(presentation_json)?;
-    let key: JWK = serde_json::from_str(key_json)?;
-    let options: JWTOrLDPOptions = serde_json::from_str(proof_options_json)?;
-    let proof_format = options.proof_format.unwrap_or_default();
+    let proof_format = proof_options.proof_format.unwrap_or_default();
     let rt = runtime::get()?;
-    let out = match proof_format {
+    match proof_format {
         ProofFormat::JWT => {
-            rt.block_on(presentation.generate_jwt(Some(&key), &options.ldp_options, resolver))?
+            rt.block_on(
+                presentation.generate_jwt(Some(&jwk), &proof_options.ldp_options, resolver)
+            ).map_err(Error::from)
         }
         ProofFormat::LDP => {
+            let mut ctx = context_loader.clone();
             let proof = rt.block_on(presentation.generate_proof(
-                &key,
-                &options.ldp_options,
+                &jwk,
+                &proof_options.ldp_options,
                 resolver,
-                &mut context_loader,
+                &mut ctx
             ))?;
-            presentation.add_proof(proof);
-            serde_json::to_string(&presentation)?
+            let mut presentation_with_proof = presentation.clone();
+            presentation_with_proof.add_proof(proof);
+            serde_json::to_string(&presentation_with_proof).map_err(Error::from)
         }
-    };
-    Ok(CString::new(out)?.into_raw())
+    }
 }
+
+
 
 /// Verify a Verifiable Presentation. Arguments are a C string containing the Verifiable
 /// Presentation to verify, and a C string containing a JSON object for the linked data proof
 /// options for verification. The return value is a newly-allocated C string containing a JSON
 /// object for the verification result, or `NULL` in case of certain errors. On successful
-/// verification, the verification result JSON object contains a "errors" property whose value is
-/// an empty array. If verification fails, either `NULL` is returned and the error can be retrieved
-/// using [`didkit_error_message`], or a verification result JSON object is returned with an "errors"
-/// array containing information about the verification error(s) encountered. A string returned
-/// from this function should be freed using [`didkit_free_string`].
-#[didkit_macros::c_export(wrap = "ccchar_or_error")]
-fn didkit_vc_verify_presentation(
-    presentation_ptr: *const c_char,
+/// verification, the verification result JSON object contains a "errors" property whose value is an
+/// empty array. If verification fails, either `NULL` is returned and the error can be retrieved
+/// using [`didkit_error_message`], or a verification result JSON object is returned with an
+/// "errors" array containing information about the verification error(s) encountered. A string
+/// returned from this function should be freed using [`didkit_free_string`].
+#[no_mangle]
+pub extern "C" fn didkit_vc_verify_presentation(
+    vp_str_ptr: *const c_char,
     proof_options_json_ptr: *const c_char,
     context_loader_ptr: *const c_char,
-) -> Result<*const c_char, Error> {
-    let vp_str = unsafe { CStr::from_ptr(presentation_ptr) }.to_str()?;
-    let proof_options_json = unsafe { CStr::from_ptr(proof_options_json_ptr) }.to_str()?;
-    // TODO
-    let options: JWTOrLDPOptions = serde_json::from_str(proof_options_json)?;
-    let proof_format = options.proof_format.unwrap_or_default();
-    let mut context_loader = load_context(context_loader_ptr)?;
+) -> *const c_char {
+    string_from_raw_ptr(vp_str_ptr)
+        .and_then(
+            |vp_str|
+            from_json_raw_ptr::<JWTOrLDPOptions>(proof_options_json_ptr)
+                .map(|proof_options| (vp_str, proof_options))
+        )
+        .and_then(
+            |(vp_str, proof_options)|
+            load_context(context_loader_ptr)
+                .map(|context_loader| (vp_str, proof_options, context_loader))
+        )
+        .and_then(
+            |(vp_str, proof_options, context_loader)|
+            vc_verify_presentation(&vp_str, proof_options, context_loader)
+        )
+        .and_then(|vr| to_json_raw_ptr(&vr))
+        .unwrap_or_else(stash_err)
+}
+
+
+fn vc_verify_presentation(
+    vp_str: &str,
+    proof_options: JWTOrLDPOptions,
+    context_loader: ssi::jsonld::ContextLoader
+) -> Result<VerificationResult, Error> {
+    let proof_format = proof_options.proof_format.unwrap_or_default();
     let rt = runtime::get()?;
     let resolver = DID_METHODS.to_resolver();
-    let result = match proof_format {
+    let mut ctx = context_loader.clone();
+    let vr = match proof_format {
         ProofFormat::JWT => rt.block_on(VerifiablePresentation::verify_jwt(
             vp_str,
-            Some(options.ldp_options),
+            Some(proof_options.ldp_options),
             resolver,
-            &mut context_loader,
+            &mut ctx,
         )),
         ProofFormat::LDP => {
             let vp = VerifiablePresentation::from_json_unsigned(vp_str)?;
             rt.block_on(vp.verify(
-                Some(options.ldp_options),
+                Some(proof_options.ldp_options),
                 DID_METHODS.to_resolver(),
-                &mut context_loader,
+                &mut ctx,
             ))
         }
     };
-    Ok(CString::new(serde_json::to_string(&result)?)?.into_raw())
+    Ok(vr)
 }
 
-/// Issue a Verifiable Presentation for [DIDAuth](https://w3c-ccg.github.io/vp-request-spec/#did-authentication-request). Input parameters are the holder URI as a C string, and JSON C strings for the linked data proof options and the JWK for signing. On success,
-/// a newly-issued verifiable presentation is returned as a newly-allocated C string. The
-/// returned string should be freed using [`didkit_free_string`]. On failure, `NULL` is returned, and the
-/// error message can be retrieved using [`didkit_error_message`].
-#[didkit_macros::c_export(wrap = "ccchar_or_error")]
-fn didkit_did_auth(
+/// Issue a Verifiable Presentation for
+/// [DIDAuth](https://w3c-ccg.github.io/vp-request-spec/#did-authentication-request). Input
+/// parameters are the holder URI as a C string, and JSON C strings for the linked data proof
+/// options and the JWK for signing. On success, a newly-issued verifiable presentation is returned
+/// as a newly-allocated C string. The returned string should be freed using
+/// [`didkit_free_string`]. On failure, `NULL` is returned, and the error message can be retrieved
+/// using [`didkit_error_message`].
+#[no_mangle]
+pub extern "C" fn didkit_did_auth(
     holder_ptr: *const c_char,
     proof_options_json_ptr: *const c_char,
     key_json_ptr: *const c_char,
     context_loader_ptr: *const c_char,
-) -> Result<*const c_char, Error> {
+) -> *const c_char {
+    string_from_raw_ptr(holder_ptr)
+        .and_then(
+            |holder|
+            from_json_raw_ptr::<JWTOrLDPOptions>(proof_options_json_ptr)
+                .map(|proof_options| (holder, proof_options))
+        )
+        .and_then(
+            |(holder, proof_options)|
+            from_json_raw_ptr::<JWK>(key_json_ptr)
+                .map(|jwk| (holder, proof_options, jwk))
+        )
+        .and_then(
+            |(holder, proof_options, jwk)|
+            load_context(context_loader_ptr)
+                .map(|context_loader| (holder, proof_options, jwk, context_loader))
+        )
+        .and_then(
+            |(holder, proof_options, jwk, context_loader)|
+            did_auth(holder, proof_options, jwk, context_loader)
+        )
+        .and_then(to_char_raw_ptr)
+        .unwrap_or_else(stash_err)
+}
+
+
+fn did_auth(
+    holder: String,
+    proof_options: JWTOrLDPOptions,
+    jwk: JWK,
+    context_loader: ssi::jsonld::ContextLoader
+) -> Result<String, Error> {
     let resolver = DID_METHODS.to_resolver();
-    let mut context_loader = load_context(context_loader_ptr)?;
-    let holder = unsafe { CStr::from_ptr(holder_ptr) }.to_str()?;
-    let proof_options_json = unsafe { CStr::from_ptr(proof_options_json_ptr) }.to_str()?;
-    let key_json = unsafe { CStr::from_ptr(key_json_ptr) }.to_str()?;
     let mut presentation = VerifiablePresentation {
-        holder: Some(ssi::vc::URI::String(holder.to_string())),
+        holder: Some(ssi::vc::URI::String(holder)),
         ..VerifiablePresentation::default()
     };
-    let key: JWK = serde_json::from_str(key_json)?;
-    let options: JWTOrLDPOptions = serde_json::from_str(proof_options_json)?;
-    let proof_format = options.proof_format.unwrap_or_default();
+
+    let proof_format = proof_options.proof_format.unwrap_or_default();
     let rt = runtime::get()?;
-    let out = match proof_format {
+    match proof_format {
         ProofFormat::JWT => {
-            rt.block_on(presentation.generate_jwt(Some(&key), &options.ldp_options, resolver))?
+            rt.block_on(
+                presentation.generate_jwt(Some(&jwk), &proof_options.ldp_options, resolver)
+            ).map_err(Error::from)
         }
         ProofFormat::LDP => {
+            let mut ctx = context_loader.clone();
             let proof = rt.block_on(presentation.generate_proof(
-                &key,
-                &options.ldp_options,
+                &jwk,
+                &proof_options.ldp_options,
                 resolver,
-                &mut context_loader,
+                &mut ctx
             ))?;
             presentation.add_proof(proof);
-            serde_json::to_string(&presentation)?
+            serde_json::to_string(&presentation).map_err(Error::from)
         }
-    };
-    Ok(CString::new(out)?.into_raw())
+    }
 }
 
 /// Resolve a DID to a DID Document. Arguments are a C string containing the DID to resolve, and a
@@ -331,54 +574,80 @@ fn didkit_did_auth(
 /// a newly-allocated C string containing either the resolved DID document or a DID resolution
 /// result JSON object. On error, `NULL` is returned, and the error can be retrieved using
 /// [`didkit_error_message`].
-#[didkit_macros::c_export(wrap = "ccchar_or_error")]
-fn didkit_resolve_did(
+#[no_mangle]
+pub extern "C" fn didkit_resolve_did(
     did_ptr: *const c_char,
     input_metadata_json_ptr: *const c_char,
-) -> Result<*const c_char, Error> {
-    let did = unsafe { CStr::from_ptr(did_ptr) }.to_str()?;
-    let input_metadata_json = if input_metadata_json_ptr.is_null() {
-        "{}"
-    } else {
-        unsafe { CStr::from_ptr(input_metadata_json_ptr) }.to_str()?
-    };
-    let input_metadata: ResolutionInputMetadata = serde_json::from_str(input_metadata_json)?;
+) -> *const c_char {
+    string_from_raw_ptr(did_ptr)
+        .and_then(
+            |did|
+            input_metadata_from_raw_ptr(input_metadata_json_ptr)
+                .map(|input_metadata| (did, input_metadata))
+        )
+        .and_then(
+            |(did, input_metadata)|
+            resolve_did(&did, input_metadata)
+        )
+        .and_then(|res_result| to_json_raw_ptr(&res_result))
+        .unwrap_or_else(stash_err)
+}
+
+
+fn resolve_did(
+    did: &str,
+    input_metadata: ResolutionInputMetadata
+) -> Result<ResolutionResult, Error> {
     let resolver = DID_METHODS.to_resolver();
     let rt = runtime::get()?;
     let (res_meta, doc_opt, doc_meta_opt) = rt.block_on(resolver.resolve(did, &input_metadata));
-    let result = ResolutionResult {
+    let res_result = ResolutionResult {
         did_document: doc_opt,
         did_resolution_metadata: Some(res_meta),
         did_document_metadata: doc_meta_opt,
         ..Default::default()
     };
-    Ok(CString::new(serde_json::to_string(&result)?)?.into_raw())
+    Ok(res_result)
 }
 
-/// Resolve a DID to a DID Document. Arguments are a C string containing the DID URL to dereference, and a
-/// C string containing a JSON object for dereferencing input metadata. The return value on success is
-/// a newly-allocated C string containing either a resolved resource or a DID resolution
+
+/// Resolve a DID to a DID Document. Arguments are a C string containing the DID URL to dereference,
+/// and a C string containing a JSON object for dereferencing input metadata. The return value on
+/// success is a newly-allocated C string containing either a resolved resource or a DID resolution
 /// result JSON object. On error, `NULL` is returned, and the error can be retrieved using
 /// [`didkit_error_message`].
-#[didkit_macros::c_export(wrap = "ccchar_or_error")]
-fn didkit_dereference_did_url(
+#[no_mangle]
+pub extern "C" fn didkit_dereference_did_url(
     did_url_ptr: *const c_char,
     input_metadata_json_ptr: *const c_char,
-) -> Result<*const c_char, Error> {
-    let did_url = unsafe { CStr::from_ptr(did_url_ptr) }.to_str()?;
-    let input_metadata_json = if input_metadata_json_ptr.is_null() {
-        "{}"
-    } else {
-        unsafe { CStr::from_ptr(input_metadata_json_ptr) }.to_str()?
-    };
-    let input_metadata: DereferencingInputMetadata = serde_json::from_str(input_metadata_json)?;
+) -> *const c_char {
+    string_from_raw_ptr(did_url_ptr)
+        .and_then(
+            |did_url|
+            dereferencing_input_metadata_from_raw_ptr(input_metadata_json_ptr)
+                .map(|input_metadata| (did_url, input_metadata))
+        )
+        .and_then(
+            |(did_url, input_metadata)|
+            dereference_did_url(&did_url, input_metadata)
+        )
+        .and_then(to_char_raw_ptr)
+        .unwrap_or_else(stash_err)
+}
+
+
+fn dereference_did_url(
+    did_url: &str,
+    input_metadata: DereferencingInputMetadata
+) -> Result<String, Error> {
     let resolver = DID_METHODS.to_resolver();
     let rt = runtime::get()?;
     let deref_result = rt.block_on(dereference(resolver, did_url, &input_metadata));
     use serde_json::json;
     let result = json!(deref_result);
-    Ok(CString::new(serde_json::to_string(&result)?)?.into_raw())
+    serde_json::to_string(&result).map_err(Error::from)
 }
+
 
 #[derive(Serialize, Deserialize)]
 struct Context {
@@ -392,32 +661,30 @@ impl Context {
     }
 }
 
-#[didkit_macros::c_export(wrap = "ccchar_or_error")]
-fn didkit_create_context(url: *const c_char, json: *const c_char) -> Result<*const c_char, Error> {
-    let url = unsafe { CStr::from_ptr(url) }.to_str()?.to_string();
-    let json = unsafe { CStr::from_ptr(json) }.to_str()?.to_string();
-    let context = Context { url, json };
-    let json = serde_json::to_string(&context)?;
-    let encoded = base64::encode(json);
-    Ok(CString::new(encoded)?.into_raw())
+#[no_mangle]
+pub extern "C" fn didkit_create_context(
+    url_ptr: *const c_char,
+    json_ptr: *const c_char
+) -> *const c_char {
+    string_from_raw_ptr(url_ptr)
+        .and_then(
+            |url|
+            string_from_raw_ptr(json_ptr).map(|json| (url, json))
+        )
+        .map(|(url, json)| Context{url, json})
+        .and_then(|ctx| to_bas64_json_raw_ptr(&ctx))
+        .unwrap_or_else(stash_err)
 }
 
-#[didkit_macros::c_export(wrap = "ccchar_or_error")]
-fn didkit_create_context_map(
+
+#[no_mangle]
+pub extern "C" fn didkit_create_context_map(
     contexts_ptr: *const *const c_char,
-    size: c_uint,
-) -> Result<*const c_char, Error> {
-    let mut contexts: Vec<String> = Vec::with_capacity(size as usize);
-    for i in 0..size as isize {
-        let context_ptr = unsafe { contexts_ptr.offset(i) };
-        let context = unsafe { CStr::from_ptr(context_ptr.read()) }
-            .to_str()?
-            .to_string();
-        contexts.push(context);
-    }
-    let json = serde_json::to_string(&contexts)?;
-    let encoded = base64::encode(json);
-    Ok(CString::new(encoded)?.into_raw())
+    size: usize,
+) -> *const c_char {
+    string_vec_from_string_array_raw_ptr(contexts_ptr, size)
+        .and_then(|ctx| to_bas64_json_raw_ptr(&ctx))
+        .unwrap_or_else(stash_err)
 }
 
 fn load_context(context_loader_ptr: *const c_char) -> Result<ssi::jsonld::ContextLoader, Error> {
@@ -441,91 +708,212 @@ fn load_context(context_loader_ptr: *const c_char) -> Result<ssi::jsonld::Contex
     }
 }
 
-#[didkit_macros::c_export(wrap = "ccchar_or_error")]
-fn didkit_vc_prepare_issue_credential(
+
+
+/// Prepares a credential for signing by an external service.
+///
+/// All parameters are pointers to json encoded strings.
+///
+/// The return is a json serialized proof preparation object which should be treated as
+/// opaque by calling applications.   It is necessary in the call to complete the credential
+/// issuance.
+#[no_mangle]
+pub extern "C" fn didkit_vc_prepare_issue_credential(
     credential_ptr: *const c_char,
     linked_data_proof_options_ptr: *const c_char,
     public_key_ptr: *const c_char,
     context_loader_ptr: *const c_char,
-) -> Result<*const c_char, Error> {
-    let credential = unsafe { CStr::from_ptr(credential_ptr) }.to_str()?;
-    let linked_data_proof_options =
-        unsafe { CStr::from_ptr(linked_data_proof_options_ptr) }.to_str()?;
-    let public_key = unsafe { CStr::from_ptr(public_key_ptr) }.to_str()?;
-    let public_key: JWK = serde_json::from_str(public_key)?;
-    let credential = VerifiableCredential::from_json_unsigned(credential)?;
-    let options: LinkedDataProofOptions = serde_json::from_str(linked_data_proof_options)?;
-    let resolver = DID_METHODS.to_resolver();
-    let mut context_loader = load_context(context_loader_ptr)?;
-    let rt = runtime::get()?;
-    let preparation = rt.block_on(credential.prepare_proof(
-        &public_key,
-        &options,
-        resolver,
-        &mut context_loader,
-    ))?;
-    Ok(CString::new(serde_json::to_string(&preparation)?)?.into_raw())
+) -> *const c_char {
+    from_json_raw_ptr::<VerifiableCredential>(credential_ptr)
+        .and_then(
+            |credential|
+            from_json_raw_ptr::<LinkedDataProofOptions>(linked_data_proof_options_ptr)
+                .map(|proof_options| (credential, proof_options))
+        )
+        .and_then(
+            |(credential, proof_options)|
+            from_json_raw_ptr::<JWK>(public_key_ptr).map(|jwk| (credential, proof_options, jwk))
+        )
+        .and_then(
+            |(credential, proof_options, jwk)|
+            load_context(context_loader_ptr).map(|ctx| (credential, proof_options, jwk, ctx))
+        )
+        .and_then(
+            |(credential, proof_options, jwk, ctx)|
+            vc_prepare_issue_credential(credential, proof_options, jwk, ctx)
+        )
+        .and_then(|preparation| to_json_raw_ptr(&preparation))
+        .unwrap_or_else(stash_err)
 }
 
-#[didkit_macros::c_export(wrap = "ccchar_or_error")]
-fn didkit_vc_complete_issue_credential(
+
+/// Prepares a credential for signing by an external service.
+fn vc_prepare_issue_credential(
+    credential: VerifiableCredential,
+    linked_data_proof_options: LinkedDataProofOptions,
+    jwk: JWK,
+    context_loader: ssi::jsonld::ContextLoader
+) -> Result<ProofPreparation, Error> {
+    let resolver = DID_METHODS.to_resolver();
+    let rt = runtime::get()?;
+    let mut ctx = context_loader.clone();
+    rt.block_on(credential.prepare_proof(
+        &jwk,
+        &linked_data_proof_options,
+        resolver,
+        &mut ctx,
+    )).map_err(Error::from)
+}
+
+
+/// Completes credential issuance after obtaining a signature from an external service.
+///
+/// credential_ptr should be the same as the credential_ptr used in
+/// didkit_vc_prepare_issue_credential
+///
+/// preparation_ptr should be the return from didkit_vc_parepare_issue_credential
+///
+/// signature_ptr should be the signature returned from the external signing service.  It must be
+/// of a form specified in the verification method of the credential.
+#[no_mangle]
+pub extern "C" fn didkit_vc_complete_issue_credential(
     credential_ptr: *const c_char,
     preparation_ptr: *const c_char,
     signature_ptr: *const c_char,
-) -> Result<*const c_char, Error> {
-    let credential = unsafe { CStr::from_ptr(credential_ptr) }.to_str()?;
-    let preparation = unsafe { CStr::from_ptr(preparation_ptr) }.to_str()?;
-    let signature = unsafe { CStr::from_ptr(signature_ptr) }.to_str()?;
-    let mut credential = VerifiableCredential::from_json_unsigned(credential)?;
-    let preparation: ProofPreparation = serde_json::from_str(preparation)?;
-    let rt = runtime::get()?;
-    let proof = rt.block_on(preparation.proof.type_.complete(&preparation, signature))?;
-    credential.add_proof(proof);
-    Ok(CString::new(serde_json::to_string(&credential)?)?.into_raw())
+) -> *const c_char {
+    from_json_raw_ptr::<VerifiableCredential>(credential_ptr)
+        .and_then(
+            |credential|
+            from_json_raw_ptr::<ProofPreparation>(preparation_ptr)
+                .map(|preparation| (credential, preparation))
+        )
+        .and_then(
+            |(credential, preparation)|
+            string_from_raw_ptr(signature_ptr).map(|signature| (credential, preparation, signature))
+        )
+        .and_then(
+            |(credential, preparation, signature)|
+            vc_complete_issue_credential(credential, preparation, signature)
+        )
+        .and_then(|credential| to_json_raw_ptr(&credential))
+        .unwrap_or_else(stash_err)
 }
 
-#[didkit_macros::c_export(wrap = "ccchar_or_error")]
-fn didkit_vc_prepare_issue_presentation(
+
+fn vc_complete_issue_credential(
+    credential: VerifiableCredential,
+    preparation: ProofPreparation,
+    signature: String
+) -> Result<VerifiableCredential, Error> {
+    let rt = runtime::get()?;
+    let proof = rt.block_on(preparation.proof.type_.complete(&preparation, &signature))?;
+    let mut credential_with_proof = credential.clone();
+    credential_with_proof.add_proof(proof);
+    Ok(credential_with_proof)
+}
+
+
+#[no_mangle]
+pub extern "C" fn didkit_vc_prepare_issue_presentation(
     presentation_ptr: *const c_char,
     linked_data_proof_options_ptr: *const c_char,
     public_key_ptr: *const c_char,
     context_loader_ptr: *const c_char,
-) -> Result<*const c_char, Error> {
-    let presentation = unsafe { CStr::from_ptr(presentation_ptr) }.to_str()?;
-    let linked_data_proof_options =
-        unsafe { CStr::from_ptr(linked_data_proof_options_ptr) }.to_str()?;
-    let public_key = unsafe { CStr::from_ptr(public_key_ptr) }.to_str()?;
-    let public_key: JWK = serde_json::from_str(public_key)?;
-    let presentation = VerifiablePresentation::from_json_unsigned(presentation)?;
-    let options: LinkedDataProofOptions = serde_json::from_str(linked_data_proof_options)?;
-    let resolver = DID_METHODS.to_resolver();
-    let mut context_loader = load_context(context_loader_ptr)?;
-    let rt = runtime::get()?;
-    let preparation = rt.block_on(presentation.prepare_proof(
-        &public_key,
-        &options,
-        resolver,
-        &mut context_loader,
-    ))?;
-    Ok(CString::new(serde_json::to_string(&preparation)?)?.into_raw())
+) -> *const c_char {
+    presentation_from_raw_ptr(presentation_ptr)
+        .and_then(
+            |presentation|
+            from_json_raw_ptr::<LinkedDataProofOptions>(linked_data_proof_options_ptr)
+                .map(|proof_options| (presentation, proof_options))
+        )
+        .and_then(
+            |(presentation, proof_options)|
+            from_json_raw_ptr::<JWK>(public_key_ptr).map(|jwk| (presentation, proof_options, jwk))
+        )
+        .and_then(
+            |(presentation, proof_options, jwk)|
+            load_context(context_loader_ptr).map(|ctx| (presentation, proof_options, jwk, ctx))
+        )
+        .and_then(
+            |(presentation, proof_options, jwk, ctx)|
+            vc_prepare_issue_presentation(presentation, proof_options, jwk, ctx)
+        )
+        .and_then(|preparation| to_json_raw_ptr(&preparation))
+        .unwrap_or_else(stash_err  )
 }
 
-#[didkit_macros::c_export(wrap = "ccchar_or_error")]
-fn didkit_vc_complete_issue_presentation(
+
+
+/// Prepares a presentation for signing by an external service.
+///
+/// All parameters are pointers to json encoded strings.
+///
+/// The return is a json serialized proof preparation object which should be treated as
+/// opaque by calling applications.   It is necessary in the call to complete the presentation
+/// issuance.
+fn vc_prepare_issue_presentation(
+    presentation: VerifiablePresentation,
+    linked_data_proof_options: LinkedDataProofOptions,
+    jwk: JWK,
+    context_loader: ssi::jsonld::ContextLoader
+) -> Result<ProofPreparation, Error> {
+    let resolver = DID_METHODS.to_resolver();
+    let rt = runtime::get()?;
+    let mut ctx = context_loader.clone();
+    rt.block_on(presentation.prepare_proof(
+        &jwk,
+        &linked_data_proof_options,
+        resolver,
+        &mut ctx,
+    )).map_err(Error::from)
+}
+
+/// Completes presentation issuance after obtaining a signature from an external service.
+///
+/// presentation_ptr should be the same as the presentation_ptr used in
+/// didkit_vc_prepare_issue_presentation
+///
+/// preparation_ptr should be the return from didkit_vc_parepare_issue_presentation
+///
+/// signature_ptr should be the signature returned from the external signing service.  It must be
+/// of a form specified in the verification method of the credential.
+#[no_mangle]
+pub extern "C" fn didkit_vc_complete_issue_presentation(
     presentation_ptr: *const c_char,
     preparation_ptr: *const c_char,
     signature_ptr: *const c_char,
-) -> Result<*const c_char, Error> {
-    let presentation = unsafe { CStr::from_ptr(presentation_ptr) }.to_str()?;
-    let preparation = unsafe { CStr::from_ptr(preparation_ptr) }.to_str()?;
-    let signature = unsafe { CStr::from_ptr(signature_ptr) }.to_str()?;
-    let mut presentation = VerifiablePresentation::from_json_unsigned(presentation)?;
-    let preparation: ProofPreparation = serde_json::from_str(preparation)?;
-    let rt = runtime::get()?;
-    let proof = rt.block_on(preparation.proof.type_.complete(&preparation, signature))?;
-    presentation.add_proof(proof);
-    Ok(CString::new(serde_json::to_string(&presentation)?)?.into_raw())
+) -> *const c_char {
+    presentation_from_raw_ptr(presentation_ptr)
+        .and_then(
+            |presentation|
+            from_json_raw_ptr::<ProofPreparation>(preparation_ptr)
+                .map(|preparation| (presentation, preparation))
+        )
+        .and_then(
+            |(presentation, preparation)|
+            string_from_raw_ptr(signature_ptr)
+                .map(|signature| (presentation, preparation, signature))
+        )
+        .and_then(
+            |(presentation, preparation, signature)|
+            vc_complete_issue_presentation(presentation, preparation, signature)
+        )
+        .and_then(|presentation| to_json_raw_ptr(&presentation))
+        .unwrap_or_else(stash_err)
 }
+
+fn vc_complete_issue_presentation(
+    presentation: VerifiablePresentation,
+    preparation: ProofPreparation,
+    signature: String
+) -> Result<VerifiablePresentation, Error> {
+    let rt = runtime::get()?;
+    let proof = rt.block_on(preparation.proof.type_.complete(&preparation, &signature))?;
+    let mut presentation_with_proof = presentation.clone();
+    presentation_with_proof.add_proof(proof);
+    Ok(presentation_with_proof)
+}
+
 
 // TODO: didkit_delegate_capability
 // TODO: didkit_prepare_delegate_capability

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -45,41 +45,6 @@ impl Parse for Args {
 }
 
 #[proc_macro_attribute]
-pub fn c_export(metadata: TokenStream, input: TokenStream) -> TokenStream {
-    let mut input_fn = parse_macro_input!(input as ItemFn);
-
-    let internal = format_ident!("f");
-    let name = input_fn.sig.ident.to_owned();
-    let args = input_fn.sig.inputs.to_owned();
-    input_fn.sig.ident = internal.to_owned();
-
-    let Args { wrap } = parse_macro_input!(metadata as Args);
-    let wrap = format_ident!("{}", wrap);
-
-    let call_args = args
-        .to_owned()
-        .into_pairs()
-        .map(Pair::into_tuple)
-        .map(|(arg, _)| match arg {
-            FnArg::Typed(PatType { pat, .. }) => match *pat {
-                Pat::Ident(PatIdent { ident, .. }) => ident,
-                _ => todo!(),
-            },
-            _ => todo!(),
-        })
-        .collect::<Vec<Ident>>();
-
-    TokenStream::from(quote! {
-        #[no_mangle]
-        pub extern "C" fn #name( #args ) -> *const c_char {
-            #input_fn
-
-            #wrap( #internal( #(#call_args),* ) )
-        }
-    })
-}
-
-#[proc_macro_attribute]
 pub fn java_export(metadata: TokenStream, input: TokenStream) -> TokenStream {
     let mut input_fn = parse_macro_input!(input as ItemFn);
 


### PR DESCRIPTION
Removes dependency on didkit_macros from the C API.

Tests covering this are in the didkit-c repo, PR:  https://github.com/spruceid/didkit-c/pull/3