### PR TITLE
Footgun fix.

### DIFF
--- a/lib/flutter/lib/didkit.dart
+++ b/lib/flutter/lib/didkit.dart
@@ -430,7 +430,12 @@ class DIDKit {
 
   static String createContextMap(List<String> contexts) {
     final size = contexts.length;
-    final array = malloc.allocate<Pointer<Utf8>>(size);
+
+    // FOOTGUN NOTE:
+    //   malloc.allocate<type>(size); → allocates 'size' *bytes*
+    //   malloc<type>(size);          → allocates 'size * sizeof(type)' bytes -- YOU WANT THIS ONE
+
+    final array = malloc<Pointer<Utf8>>(size);
 
     final native = contexts.map((c) => c.toNativeUtf8()).toList();
 


### PR DESCRIPTION
This is the apparent cause of the allocator crash; a subtle bit of API misdesign. We were allocating as many bytes as we had string pointers to store, and then writing full string pointers over top.  This overran the array, stomped the allocator metadata at the beginning of the next thing in memory, and when that thing was returned to the allocator, the integrity checking in the allocator noticed the damage and brought everything down in flames.
