### PR TITLE
4579767343 -- Feat/bump flutter ffi version

### DIFF
--- a/lib/flutter/pubspec.yaml
+++ b/lib/flutter/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  ffi: ^1.0.0
+  ffi: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/lib/ios/Sources/DIDKitSwift/DIDKit.swift
+++ b/lib/ios/Sources/DIDKitSwift/DIDKit.swift
@@ -69,7 +69,7 @@ public enum DIDKit {
     options: String,
     jwk: String
   ) throws -> String {
-    guard let vcPtr = didkit_vc_issue_credential(credential, options, jwk) else {
+    guard let vcPtr = didkit_vc_issue_credential(credential, options, jwk, nil) else {
       throw Error()
     }
     defer { didkit_free_string(vcPtr) }
@@ -77,7 +77,7 @@ public enum DIDKit {
   }
 
   public static func verifyCredential(credential: String, options: String) throws -> String {
-    guard let resultPtr = didkit_vc_verify_credential(credential, options) else {
+      guard let resultPtr = didkit_vc_verify_credential(credential, options, nil) else {
       throw Error()
     }
     defer { didkit_free_string(resultPtr) }
@@ -89,7 +89,7 @@ public enum DIDKit {
     options: String,
     jwk: String
   ) throws -> String {
-    guard let presentationPtr = didkit_vc_issue_presentation(presentation, options, jwk) else {
+    guard let presentationPtr = didkit_vc_issue_presentation(presentation, options, jwk, nil) else {
       throw Error()
     }
     defer { didkit_free_string(presentationPtr) }
@@ -97,7 +97,7 @@ public enum DIDKit {
   }
 
   public static func verifyPresentation(presentation: String, options: String) throws -> String {
-    guard let resultPtr = didkit_vc_verify_presentation(presentation, options) else {
+    guard let resultPtr = didkit_vc_verify_presentation(presentation, options, nil) else {
       throw Error()
     }
     defer { didkit_free_string(resultPtr) }
@@ -121,7 +121,7 @@ public enum DIDKit {
   }
 
   public static func didAuth(holder: String, options: String, jwk: String) throws -> String {
-    guard let vpPtr = didkit_did_auth(holder, options, jwk) else {
+      guard let vpPtr = didkit_did_auth(holder, options, jwk, nil) else {
       throw Error()
     }
     defer { didkit_free_string(vpPtr) }


### PR DESCRIPTION
Bump the flutter FFI version to allow for building credible app with newer versions of flutter after: https://github.com/spruceid/credible-mdl/pull/139

Also includes fixes for building with default context loader args.