### PR TITLE
fix GitHub workflow badge URL again

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-[![](https://img.shields.io/github/workflow/status/spruceid/didkit/ci)](https://github.com/spruceid/didkit/actions?query=workflow%3Aci+branch%3Amain) [![](https://img.shields.io/badge/Docker-19.03.x-blue)](https://www.docker.com/) [![](https://img.shields.io/badge/ssi-v0.1-green)](https://www.github.com/spruceid/ssi) [![](https://img.shields.io/badge/License-Apache--2.0-green)](https://github.com/spruceid/didkit/blob/main/LICENSE) [![](https://img.shields.io/twitter/follow/spruceid?label=Follow&style=social)](https://twitter.com/spruceid)
+[![](https://img.shields.io/github/actions/workflow/status/spruceid/didkit/build.yml?branch=main)](https://github.com/spruceid/didkit/actions?query=workflow%3Aci+branch%3Amain)
+[![](https://img.shields.io/badge/Docker-19.03.x-blue)](https://www.docker.com/)
+[![](https://img.shields.io/badge/ssi-v0.1-green)](https://www.github.com/spruceid/ssi)
+[![](https://img.shields.io/badge/License-Apache--2.0-green)](https://github.com/spruceid/didkit/blob/main/LICENSE)
+[![](https://img.shields.io/twitter/follow/spruceid?label=Follow&style=social)](https://twitter.com/spruceid)
 
 Check out the DIDKit documentation [here](https://spruceid.dev/didkit/didkit/).
 


### PR DESCRIPTION
I had to fix GitHub workflow badge URL again.
Looks like the changes from [PR #373](https://github.com/spruceid/didkit/pull/373) got undone in [PR #375](https://github.com/spruceid/didkit/pull/375). 

Also, I added new lines between badges to make the diff more readable.
If it doesn't fit the rules for didkit, feel free to close it.