### PR TITLE
Fixing a typo

### DIFF
--- a/http/defaults.toml
+++ b/http/defaults.toml
@@ -7,4 +7,5 @@ address = [127, 0, 0, 1]
 bodysizelimit = 2097152 # 2MiB
 
 [default.issuer]
+# DIDKIT_HTTP_ISSUER_KEYS
 # keys = '[<JWK>, <JWK>]'

--- a/http/defaults.toml
+++ b/http/defaults.toml
@@ -7,4 +7,4 @@ address = [127, 0, 0, 1]
 bodysizelimit = 2097152 # 2MiB
 
 [default.issuer]
-# DIDKIT_HTTP_ISSUER_KEYS = '[<JWK>, <JWK>]'
+# keys = '[<JWK>, <JWK>]'


### PR DESCRIPTION
This seems to be a simple typo. `http/src/config.rs` has:
```rust
#[serde_as]
#[derive(Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
pub struct Issuer {
    #[serde_as(as = "Option<JsonString>")]
    pub keys: Option<Vec<JWK>>,
}
``` 