### PR TITLE
build(fix): stop using path dependencies to fix corrupt build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = ["cli", "lib", "lib/cbindings", "lib/web"]
 
-default-members = ["http", "cli", "lib", "lib/cbindings"]
+default-members = ["cli", "lib", "lib/cbindings"]
 
 # $ cargo release
 [workspace.metadata.release]

--- a/README.md
+++ b/README.md
@@ -29,11 +29,6 @@ process is in place.
 
 DIDKit is written in [Rust][]. To get Rust, you can use [Rustup][].
 
-Spruce's [ssi][] library must be cloned alongside the `didkit` repository:
-```sh
-$ git clone https://github.com/spruceid/ssi ../ssi --recurse-submodules
-```
-
 Build DIDKit using [Cargo][]:
 ```sh
 $ cargo build

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -38,17 +38,16 @@ http-did = ["ssi/http-did"]
 ring = ["ssi/ring"]
 
 [dependencies]
-ssi = { version = "0.7.0", path = "../../ssi", default-features = false }
-did-method-key = { version = "0.2.0", path = "../../ssi/did-key", default-features = false }
-did-tz = { version = "0.2.0", path = "../../ssi/did-tezos" }
-did-ethr = { version = "0.2", path = "../../ssi/did-ethr", default-features = false }
-did-pkh = { version = "0.2", path = "../../ssi/did-pkh" }
-#did-sol = { version = "0.0.1", path = "../../ssi/did-sol" }
-did-web = { version = "0.2.0", path = "../../ssi/did-web", default-features = false }
-did-webkey = { version = "0.2", path = "../../ssi/did-webkey", default-features = false }
-did-onion = { version = "0.2.0", path = "../../ssi/did-onion", default-features = false }
-did-ion = { version = "0.2.0", path = "../../ssi/did-ion", default-features = false }
-did-jwk = { version = "^0.1.0", path = "../../ssi/did-jwk", default-features = false }
+ssi = { version = "0.7.0", default-features = false }
+did-method-key = { version = "0.2.0", default-features = false }
+did-tz = "0.2.0"
+did-ethr = { version = "0.2", default-features = false }
+did-pkh = "0.2"
+did-web = { version = "0.2.0", default-features = false }
+did-webkey = { version = "0.2", default-features = false }
+did-onion = { version = "0.2.0", default-features = false }
+did-ion = { version = "0.2.0", default-features = false }
+did-jwk = { version = "^0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 # TODO feature-gate JNI, or extract it in another crate like we do for Python (and probably WASM as well)


### PR DESCRIPTION
Fixes: https://github.com/spruceid/didkit/issues/389

This PR is the "plan 1" in the "What to do?" section in the https://github.com/spruceid/didkit/issues/389 .

It also fixes a build bug derived from this commit: https://github.com/spruceid/didkit/commit/aacc94fbc16da435527a3ee6a7493516206c7e44
(`http` member must have been removed)